### PR TITLE
feat: auto-logout on inactivity [FE-29] Secure Session Management

### DIFF
--- a/frontend/app/[locale]/providers.tsx
+++ b/frontend/app/[locale]/providers.tsx
@@ -3,12 +3,13 @@
 import { ThemeProvider } from "next-themes";
 import { ReactNode } from "react";
 import { FreighterProvider } from "@/contexts/FreighterContext";
+import { SessionProvider } from "@/contexts/SessionContext";
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <FreighterProvider>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-        {children}
+        <SessionProvider>{children}</SessionProvider>
       </ThemeProvider>
     </FreighterProvider>
   );

--- a/frontend/contexts/SessionContext.tsx
+++ b/frontend/contexts/SessionContext.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useFreighter } from "@/contexts/FreighterContext";
+import { useIdleTimer } from "@/hooks/useIdleTimer";
+
+/** Inactivity allowed before auto-logout. */
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+/** How long before logout to warn the user. */
+const WARNING_BEFORE_MS = 60 * 1000; // 60 seconds
+const CROSS_TAB_KEY = "aegis_last_activity";
+
+interface SessionContextValue {
+  /** True while the inactivity warning is showing. */
+  isWarning: boolean;
+  /** Seconds left before auto-logout while warning is active. */
+  secondsRemaining: number;
+  /** True right after an inactivity logout, until dismissed. */
+  loggedOutByInactivity: boolean;
+  /** Cancel the warning and keep the session alive. */
+  stayConnected: () => void;
+}
+
+const SessionContext = createContext<SessionContextValue | undefined>(undefined);
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const { isConnected, disconnect } = useFreighter();
+  const [isWarning, setIsWarning] = useState(false);
+  const [loggedOutByInactivity, setLoggedOutByInactivity] = useState(false);
+  const [secondsRemaining, setSecondsRemaining] = useState(0);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopCountdown = useCallback(() => {
+    if (countdownRef.current) {
+      clearInterval(countdownRef.current);
+      countdownRef.current = null;
+    }
+  }, []);
+
+  const handleIdle = useCallback(() => {
+    stopCountdown();
+    setIsWarning(false);
+    disconnect();
+    setLoggedOutByInactivity(true);
+  }, [disconnect, stopCountdown]);
+
+  const { reset, getRemaining } = useIdleTimer({
+    timeout: IDLE_TIMEOUT_MS,
+    promptBeforeIdle: WARNING_BEFORE_MS,
+    enabled: isConnected,
+    crossTabKey: CROSS_TAB_KEY,
+    onIdle: handleIdle,
+    onPrompt: () => {
+      setSecondsRemaining(Math.ceil(WARNING_BEFORE_MS / 1000));
+      setIsWarning(true);
+    },
+    onActive: () => {
+      stopCountdown();
+      setIsWarning(false);
+    },
+  });
+
+  // Tick the warning countdown while the prompt is visible.
+  useEffect(() => {
+    if (!isWarning) {
+      stopCountdown();
+      return;
+    }
+    countdownRef.current = setInterval(() => {
+      setSecondsRemaining(Math.max(0, Math.ceil(getRemaining() / 1000)));
+    }, 1000);
+    return stopCountdown;
+  }, [isWarning, getRemaining, stopCountdown]);
+
+  // Clear any lingering warning if the wallet disconnects by other means.
+  useEffect(() => {
+    if (!isConnected) {
+      stopCountdown();
+      setIsWarning(false);
+    }
+  }, [isConnected, stopCountdown]);
+
+  const stayConnected = useCallback(() => {
+    setIsWarning(false);
+    stopCountdown();
+    reset();
+  }, [reset, stopCountdown]);
+
+  return (
+    <SessionContext.Provider
+      value={{ isWarning, secondsRemaining, loggedOutByInactivity, stayConnected }}
+    >
+      {children}
+
+      {isWarning && (
+        <div
+          role="alertdialog"
+          aria-live="assertive"
+          aria-label="Inactivity warning"
+          className="fixed bottom-4 right-4 z-50 w-[min(92vw,22rem)] rounded-xl border border-amber-500/30 bg-white p-4 shadow-lg dark:bg-zinc-900"
+        >
+          <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            Still there?
+          </p>
+          <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+            You&apos;ll be signed out in {secondsRemaining}s due to inactivity.
+          </p>
+          <div className="mt-3 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={stayConnected}
+              className="rounded-lg bg-emerald-500 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-emerald-600"
+            >
+              Stay connected
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loggedOutByInactivity && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="fixed bottom-4 right-4 z-50 w-[min(92vw,22rem)] rounded-xl border border-rose-500/30 bg-white p-4 shadow-lg dark:bg-zinc-900"
+        >
+          <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            Signed out
+          </p>
+          <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+            You were signed out due to inactivity. Reconnect your wallet to continue.
+          </p>
+          <div className="mt-3 flex justify-end">
+            <button
+              type="button"
+              onClick={() => setLoggedOutByInactivity(false)}
+              className="rounded-lg border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 transition hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+    </SessionContext.Provider>
+  );
+}
+
+export function useSession(): SessionContextValue {
+  const ctx = useContext(SessionContext);
+  if (!ctx) {
+    throw new Error("useSession must be used within a SessionProvider");
+  }
+  return ctx;
+}

--- a/frontend/contexts/index.ts
+++ b/frontend/contexts/index.ts
@@ -1,3 +1,6 @@
 // Clean exports for FreighterContext
 export { FreighterProvider, useFreighter } from './FreighterContext';
 export type { FreighterContextType } from './FreighterContext';
+
+// Clean exports for SessionContext
+export { SessionProvider, useSession } from './SessionContext';

--- a/frontend/hooks/useIdleTimer.ts
+++ b/frontend/hooks/useIdleTimer.ts
@@ -1,0 +1,173 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+export interface UseIdleTimerOptions {
+  /** Total inactivity allowed before onIdle fires, in ms. */
+  timeout: number;
+  /** Lead time before idle to fire onPrompt (warning), in ms. 0 disables the prompt. */
+  promptBeforeIdle?: number;
+  /** Fired when the full timeout elapses with no activity. */
+  onIdle: () => void;
+  /** Fired promptBeforeIdle ms before idle, so the UI can warn the user. */
+  onPrompt?: () => void;
+  /** Fired on the first activity after a prompt was shown, so the UI can dismiss the warning. */
+  onActive?: () => void;
+  /** When false, all timers/listeners are torn down. Default true. */
+  enabled?: boolean;
+  /** DOM events that count as activity. */
+  events?: string[];
+  /** localStorage key used to sync activity across tabs. */
+  crossTabKey?: string;
+  /** Minimum ms between activity-driven resets (throttle). Default 1000. */
+  throttleMs?: number;
+}
+
+export interface IdleTimerControls {
+  /** Manually mark activity and restart the countdown. */
+  reset: () => void;
+  /** Milliseconds remaining until idle (0 if already idle/disabled). */
+  getRemaining: () => number;
+}
+
+const DEFAULT_EVENTS = [
+  "mousemove",
+  "mousedown",
+  "keydown",
+  "touchstart",
+  "scroll",
+  "wheel",
+];
+
+export function useIdleTimer(options: UseIdleTimerOptions): IdleTimerControls {
+  const {
+    timeout,
+    promptBeforeIdle = 0,
+    onIdle,
+    onPrompt,
+    onActive,
+    enabled = true,
+    events = DEFAULT_EVENTS,
+    crossTabKey,
+    throttleMs = 1000,
+  } = options;
+
+  // Keep the latest callbacks in refs so the effect doesn't re-subscribe on every render.
+  const onIdleRef = useRef(onIdle);
+  const onPromptRef = useRef(onPrompt);
+  const onActiveRef = useRef(onActive);
+  useEffect(() => {
+    onIdleRef.current = onIdle;
+    onPromptRef.current = onPrompt;
+    onActiveRef.current = onActive;
+  }, [onIdle, onPrompt, onActive]);
+
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const promptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const expiresAtRef = useRef<number>(0);
+  const lastResetRef = useRef<number>(0);
+  const promptShownRef = useRef<boolean>(false);
+
+  const clearTimers = useCallback(() => {
+    if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    if (promptTimerRef.current) clearTimeout(promptTimerRef.current);
+    idleTimerRef.current = null;
+    promptTimerRef.current = null;
+  }, []);
+
+  // schedule() arms the timers. `broadcast` controls whether we write to localStorage
+  // (true for local activity, false when reacting to another tab to avoid a loop).
+  const schedule = useRef<(broadcast: boolean) => void>(() => {});
+
+  schedule.current = (broadcast: boolean) => {
+    if (!enabled) return;
+    clearTimers();
+
+    if (promptShownRef.current) {
+      promptShownRef.current = false;
+      onActiveRef.current?.();
+    }
+
+    const now = Date.now();
+    expiresAtRef.current = now + timeout;
+
+    if (promptBeforeIdle > 0 && promptBeforeIdle < timeout) {
+      promptTimerRef.current = setTimeout(() => {
+        promptShownRef.current = true;
+        onPromptRef.current?.();
+      }, timeout - promptBeforeIdle);
+    }
+
+    idleTimerRef.current = setTimeout(() => {
+      promptShownRef.current = false;
+      onIdleRef.current();
+    }, timeout);
+
+    if (broadcast && crossTabKey && typeof window !== "undefined") {
+      try {
+        window.localStorage.setItem(crossTabKey, String(now));
+      } catch {
+        // ignore storage failures (private mode, quota)
+      }
+    }
+  };
+
+  const reset = useCallback(() => {
+    schedule.current(true);
+  }, []);
+
+  const getRemaining = useCallback(() => {
+    if (!enabled) return 0;
+    return Math.max(0, expiresAtRef.current - Date.now());
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") {
+      clearTimers();
+      return;
+    }
+
+    schedule.current(false);
+
+    const handleActivity = () => {
+      const now = Date.now();
+      if (now - lastResetRef.current < throttleMs) return;
+      lastResetRef.current = now;
+      schedule.current(true);
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState !== "visible") return;
+      // Reconcile after the tab was backgrounded: if we're past expiry, go idle now.
+      if (Date.now() >= expiresAtRef.current) {
+        clearTimers();
+        promptShownRef.current = false;
+        onIdleRef.current();
+      }
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      if (!crossTabKey || event.key !== crossTabKey || event.newValue === null) return;
+      // Another tab saw activity — restart our countdown without re-broadcasting.
+      schedule.current(false);
+    };
+
+    for (const evt of events) {
+      window.addEventListener(evt, handleActivity, { passive: true });
+    }
+    document.addEventListener("visibilitychange", handleVisibility);
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      for (const evt of events) {
+        window.removeEventListener(evt, handleActivity);
+      }
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("storage", handleStorage);
+      clearTimers();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, timeout, promptBeforeIdle, throttleMs, crossTabKey, events.join(",")]);
+
+  return { reset, getRemaining };
+}


### PR DESCRIPTION
## Summary

Implements **[FE-29] Secure Session Management** (#63): auto-logout on inactivity.

- **Inactivity timer** — a reusable `useIdleTimer` hook (`frontend/hooks/useIdleTimer.ts`) tracks user activity (mouse move/down, keydown, touch, scroll, wheel), throttles resets, syncs activity **across tabs** via a `storage` event, and reconciles on tab focus so a backgrounded tab still logs out on time.
- **Wallet disconnect on timeout** — a `SessionProvider` (`frontend/contexts/SessionContext.tsx`) runs the timer only while a wallet is connected and calls the existing Freighter `disconnect()` when it fires. Default timeout is **15 minutes**.
- **UX** — a non-blocking warning toast appears **60s before** logout with a *"Stay connected"* action, and a confirmation toast explains when a session ended due to inactivity. Both are theme-aware and accessible (`role="alertdialog"` / `role="alert"`, `aria-live`).
- Mounted app-wide in `app/[locale]/providers.tsx` (inside the Freighter + theme providers) and exported from the `contexts` barrel.

## Acceptance criteria
- [x] Implement inactivity timer
- [x] Trigger wallet disconnect on timeout

## Test plan
- [x] `cd frontend && npm install --legacy-peer-deps && npm run build` — succeeds; TypeScript passes for the new files. (Pre-existing warnings — `middleware`→`proxy` deprecation, multiple lockfiles — are unrelated.)
- Frontend-only change; smart contracts are untouched.

Closes #63

cc @bbkenny — ready for review.