### PR TITLE
[FE-22] Mobile Responsiveness Audit

### DIFF
--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Providers } from "./providers";
 import { NextIntlClientProvider } from 'next-intl';
@@ -6,6 +6,11 @@ import { getMessages } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { routing } from '../../i18n/routing';
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
 
 export const metadata: Metadata = {
   title: "X-Aegis",

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 
-import { useState } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -11,7 +11,7 @@ import { VaultOverviewCard } from "../../components/VaultOverviewCard";
 import { VaultAPYChart } from "../../components/charts/VaultAPYChart";
 import { TransactionHistoryList } from "@/components/transactions/TransactionHistoryList";
 import Link from "next/link";
-import { TrendingUp, Shield, BarChart3, ArrowUpRight } from "lucide-react";
+import { TrendingUp, Shield, BarChart3, ArrowUpRight, Menu, X } from "lucide-react";
 import { RiskChart } from "../../components/RiskChart";
 import { RiskBadge } from "../../components/RiskBadge";
 import { WithdrawTab } from "../../components/WithdrawTab";
@@ -33,17 +33,92 @@ const MOCK_RISK_DATA = [
 export default function Home() {
   const t = useTranslations('HomePage');
   const [activeTab, setActiveTab] = useState("dashboard");
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setMobileMenuOpen(false);
+  }, [activeTab]);
+
+  const closeMobileMenu = useCallback(() => setMobileMenuOpen(false), []);
 
   return (
     <main className="flex min-h-screen flex-col bg-background text-foreground">
+      {/* Mobile Menu Overlay */}
+      {mobileMenuOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 md:hidden"
+          onClick={closeMobileMenu}
+        />
+      )}
+
+      {/* Mobile Menu Drawer */}
+      <div
+        className={`fixed top-0 right-0 h-full w-64 bg-card border-l border-border z-50 transform transition-transform duration-300 ease-in-out md:hidden ${
+          mobileMenuOpen ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <span className="font-bold text-lg">Menu</span>
+          <button
+            onClick={closeMobileMenu}
+            className="p-2 hover:bg-muted rounded-lg transition-colors"
+            aria-label="Close menu"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <nav className="flex flex-col p-4 gap-1">
+          {[
+            { key: "dashboard", label: t('dashboard') },
+            { key: "referrals", label: t('referrals') },
+            { key: "vaults", label: t('vaults'), href: "#" },
+            { key: "swap", label: t('swap'), href: "#" },
+            { key: "settings", label: t('settings'), href: "/settings" },
+          ].map((item) =>
+            item.href ? (
+              <Link
+                key={item.key}
+                href={item.href}
+                onClick={closeMobileMenu}
+                className="w-full text-left px-4 py-3 rounded-xl text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <button
+                key={item.key}
+                onClick={() => { setActiveTab(item.key); }}
+                className={`w-full text-left px-4 py-3 rounded-xl text-sm font-medium transition-colors ${activeTab === item.key ? "bg-primary/10 text-primary" : "text-muted-foreground hover:bg-accent hover:text-foreground"}`}
+              >
+                {item.label}
+              </button>
+            )
+          )}
+          <div className="border-t border-border mt-2 pt-4 flex flex-col gap-2">
+            <button
+              onClick={() => setActiveTab("deposit")}
+              className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-semibold transition-all ${activeTab === "deposit" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
+            >
+              {t('deposit')}
+            </button>
+            <button
+              onClick={() => setActiveTab("withdraw")}
+              className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-semibold transition-all ${activeTab === "withdraw" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
+            >
+              {t('withdraw')}
+            </button>
+          </div>
+        </nav>
+      </div>
+
       {/* Navigation / Header */}
-      <header className="border-b border-border bg-card/30 backdrop-blur-md sticky top-0 z-50">
-        <div className="container mx-auto px-6 h-16 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
+      <header className="border-b border-border bg-card/30 backdrop-blur-md sticky top-0 z-30">
+        <div className="container mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
+          <div className="flex items-center gap-2 shrink-0">
+            <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center shrink-0">
               <Shield className="text-primary-foreground w-5 h-5" />
             </div>
-            <span className="text-xl font-bold tracking-tight">X-Aegis</span>
+            <span className="text-lg sm:text-xl font-bold tracking-tight">X-Aegis</span>
           </div>
           <nav className="hidden md:flex gap-8 text-sm font-medium text-muted-foreground">
             <button 
@@ -62,27 +137,34 @@ export default function Home() {
             <Link href="#" className="hover:text-foreground transition-colors">{t('swap')}</Link>
             <Link href="/settings" className="hover:text-foreground transition-colors">{t('settings')}</Link>
           </nav>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 sm:gap-4">
             <button 
               onClick={() => setActiveTab("deposit")}
-              className={`px-4 py-2 rounded-lg text-sm font-semibold transition-all ${activeTab === "deposit" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
+              className={`hidden sm:inline-flex px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold transition-all ${activeTab === "deposit" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
             >
               {t('deposit')}
             </button>
             <button 
               onClick={() => setActiveTab("withdraw")}
-              className={`px-4 py-2 rounded-lg text-sm font-semibold transition-all ${activeTab === "withdraw" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
+              className={`hidden sm:inline-flex px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold transition-all ${activeTab === "withdraw" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
             >
               {t('withdraw')}
             </button>
-            <button className="bg-primary text-primary-foreground px-4 py-2 rounded-lg text-sm font-semibold hover:bg-primary/90 transition-all shadow-lg shadow-primary/20">
+            <button className="bg-primary text-primary-foreground px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold hover:bg-primary/90 transition-all shadow-lg shadow-primary/20 whitespace-nowrap">
               {t('connectWallet')}
+            </button>
+            <button
+              onClick={() => setMobileMenuOpen(true)}
+              className="md:hidden p-2 hover:bg-muted rounded-lg transition-colors"
+              aria-label="Open menu"
+            >
+              <Menu className="w-5 h-5" />
             </button>
           </div>
         </div>
       </header>
 
-      <div className="container mx-auto px-6 py-8">
+      <div className="container mx-auto px-4 sm:px-6 py-6 sm:py-8">
         {activeTab === "dashboard" ? (
           <>
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-10 gap-4">

--- a/frontend/app/[locale]/settings/page.tsx
+++ b/frontend/app/[locale]/settings/page.tsx
@@ -41,7 +41,7 @@ export default function SettingsPage() {
         </div>
       </header>
 
-      <main className="container mx-auto px-6 py-8 flex-1 max-w-4xl">
+      <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8 flex-1 max-w-4xl">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Sidebar */}
           <aside className="space-y-1">
@@ -102,7 +102,7 @@ export default function SettingsPage() {
                 </div>
 
                 {/* Currency Selector */}
-                <div className="flex items-center justify-between pt-2">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between pt-2 gap-3 sm:gap-0">
                   <div className="space-y-1">
                     <p className="font-semibold text-sm flex items-center gap-2">
                       <Coins className="w-4 h-4 text-muted-foreground" />
@@ -113,7 +113,7 @@ export default function SettingsPage() {
                   <select 
                     value={currency} 
                     onChange={(e) => setCurrency(e.target.value)}
-                    className="bg-accent/50 border border-border rounded-lg text-sm px-3 py-1.5 focus:ring-1 focus:ring-primary outline-none"
+                    className="bg-accent/50 border border-border rounded-lg text-sm px-3 py-1.5 focus:ring-1 focus:ring-primary outline-none w-full sm:w-auto"
                   >
                     <option value="USD">USD (Global)</option>
                     <option value="NGN">NGN (Nigeria)</option>

--- a/frontend/app/[locale]/vaults/[id]/page.tsx
+++ b/frontend/app/[locale]/vaults/[id]/page.tsx
@@ -33,19 +33,19 @@ export default function VaultDetailsPage() {
         </div>
       </header>
 
-      <main className="container mx-auto px-6 py-10 flex-grow">
-         <div className="grid grid-cols-1 lg:grid-cols-3 gap-10">
+      <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-10 flex-grow">
+         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-10">
             {/* Left Column: Stats and Info */}
             <div className="lg:col-span-2 space-y-8">
-               <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
+                <div className="flex flex-col md:flex-row md:items-end justify-between gap-3 md:gap-4">
                   <div>
-                    <h1 className="text-4xl font-black tracking-tighter mb-2">{vaultName}</h1>
+                    <h1 className="text-2xl sm:text-3xl md:text-4xl font-black tracking-tighter mb-2">{vaultName}</h1>
                     <div className="flex items-center gap-3">
                        <span className="bg-primary/10 text-primary text-[10px] font-black uppercase tracking-wider px-2 py-1 rounded">Delta Neutral</span>
                        <span className="bg-green-500/10 text-green-500 text-[10px] font-black uppercase tracking-wider px-2 py-1 rounded">Audited</span>
                     </div>
                   </div>
-                  <div className="flex items-end gap-10">
+                  <div className="flex items-end gap-6 sm:gap-10">
                      <div className="text-right">
                         <p className="text-[10px] text-muted-foreground uppercase font-black tracking-widest mb-1">Current Yield</p>
                         <p className="text-4xl font-black text-green-500">{apy}</p>

--- a/frontend/components/AiInsightStream.tsx
+++ b/frontend/components/AiInsightStream.tsx
@@ -63,41 +63,39 @@ export const AiInsightStream: React.FC = () => {
   const getMessageStyle = (type: InsightType) => {
     switch (type) {
       case "REBALANCE":
-        return "text-[#00ffcc] font-bold border-l-2 border-[#00ffcc] pl-2 bg-[#00ffcc]/10";
+        return "text-primary font-bold border-l-2 border-primary pl-2 bg-primary/10";
       case "WARNING":
-        return "text-yellow-400 font-medium";
+        return "text-yellow-600 dark:text-yellow-400 font-medium";
       default:
-        return "text-gray-400";
+        return "text-muted-foreground";
     }
   };
 
   return (
-    <div className="w-full max-w-2xl bg-[#0a0a0b] rounded-xl border border-white/10 overflow-hidden shadow-2xl">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-white/10 bg-white/5">
+    <div className="w-full max-w-2xl bg-card rounded-xl border border-border overflow-hidden shadow-lg">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-accent/30">
         <div className="flex items-center gap-2">
           <div className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
-          <h2 className="text-sm font-semibold text-white/90 uppercase tracking-wider">AI Insight Stream</h2>
+          <h2 className="text-sm font-semibold uppercase tracking-wider">AI Insight Stream</h2>
         </div>
-        <div className="text-[10px] text-gray-500 font-mono">LIVE_FEED_v1.0</div>
+        <div className="text-[10px] text-muted-foreground font-mono">LIVE_FEED_v1.0</div>
       </div>
       
       <div 
         ref={scrollRef}
-        className="h-[300px] overflow-y-auto p-4 space-y-3 font-mono text-xs custom-scrollbar"
+        className="h-48 sm:h-56 md:h-[300px] overflow-y-auto p-4 space-y-3 font-mono text-xs custom-scrollbar"
       >
         {insights.map((insight) => (
-          <div 
-            key={insight.id} 
-            className={`p-2 rounded transition-all duration-300 hover:bg-white/5 ${getMessageStyle(insight.type)}`}
-          >
+            <div className={`p-2 rounded transition-all duration-300 hover:bg-accent/50 ${getMessageStyle(insight.type)}`}
+            >
             <div className="flex justify-between items-start gap-4">
               <span className="flex-1">{insight.message}</span>
-              <span className="text-[10px] text-gray-600 whitespace-nowrap">{insight.timestamp}</span>
+              <span className="text-[10px] text-muted-foreground/60 whitespace-nowrap shrink-0">{insight.timestamp}</span>
             </div>
             {insight.type === "REBALANCE" && (
               <div className="mt-1 flex items-center gap-1">
-                <span className="w-3 h-[1px] bg-[#00ffcc]" />
-                <span className="text-[9px] uppercase tracking-tighter opacity-80">Execution Confirmed</span>
+                <span className="w-3 h-[1px] bg-primary" />
+                <span className="text-[9px] uppercase tracking-tighter text-muted-foreground/70">Execution Confirmed</span>
               </div>
             )}
           </div>
@@ -112,11 +110,11 @@ export const AiInsightStream: React.FC = () => {
           background: transparent;
         }
         .custom-scrollbar::-webkit-scrollbar-thumb {
-          background: rgba(255, 255, 255, 0.1);
+          background: hsl(var(--border));
           border-radius: 10px;
         }
         .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-          background: rgba(255, 255, 255, 0.2);
+          background: hsl(var(--muted-foreground) / 0.3);
         }
       `}</style>
     </div>

--- a/frontend/components/ReferralLinkCard.tsx
+++ b/frontend/components/ReferralLinkCard.tsx
@@ -34,7 +34,7 @@ export function ReferralLinkCard() {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex gap-2">
+        <div className="flex flex-col sm:flex-row gap-2">
           <div className="relative flex-1">
             <Input 
               value={referralLink} 

--- a/frontend/components/ReferralStatsCard.tsx
+++ b/frontend/components/ReferralStatsCard.tsx
@@ -47,17 +47,17 @@ export function ReferralStatsCard() {
         <CardContent>
           <div className="space-y-4">
             {MOCK_REFERRALS.map((ref) => (
-              <div key={ref.id} className="flex justify-between items-center pb-4 border-b border-border last:border-0 last:pb-0">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-muted rounded-full flex items-center justify-center">
+              <div key={ref.id} className="flex justify-between items-center gap-2 pb-4 border-b border-border last:border-0 last:pb-0">
+                <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+                  <div className="w-8 h-8 bg-muted rounded-full flex items-center justify-center shrink-0">
                     <Wallet className="w-4 h-4 text-muted-foreground" />
                   </div>
-                  <div>
-                    <p className="text-sm font-bold font-mono">{ref.user}</p>
+                  <div className="min-w-0">
+                    <p className="text-xs sm:text-sm font-bold font-mono truncate">{ref.user}</p>
                     <p className="text-[10px] text-muted-foreground uppercase">{ref.date}</p>
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="text-right shrink-0">
                   <p className="text-sm font-bold">{ref.bonus}</p>
                   <p className={`text-[10px] uppercase font-bold ${ref.status === 'Active' ? 'text-green-500' : 'text-yellow-500'}`}>
                     {ref.status}

--- a/frontend/components/RiskChart.tsx
+++ b/frontend/components/RiskChart.tsx
@@ -32,7 +32,7 @@ export function RiskChart({ data, height = 200 }: RiskChartProps) {
                 <svg
                     viewBox={`0 0 400 ${height}`}
                     className="w-full h-full overflow-visible"
-                    preserveAspectRatio="none"
+                    preserveAspectRatio="xMidYMid meet"
                 >
                     {/* Grid lines */}
                     <line x1="0" y1="0" x2="400" y2="0" stroke="currentColor" strokeOpacity="0.1" />
@@ -81,9 +81,9 @@ export function RiskChart({ data, height = 200 }: RiskChartProps) {
             </div>
 
             {/* Date labels */}
-            <div className="flex justify-between mt-4">
+            <div className="flex justify-between mt-2 sm:mt-4">
                 {data.map((d, i) => (
-                    <span key={i} className="text-[10px] text-muted-foreground uppercase font-medium">
+                    <span key={i} className="text-[8px] sm:text-[10px] text-muted-foreground uppercase font-medium truncate max-w-[40px] sm:max-w-none text-center">
                         {d.date}
                     </span>
                 ))}

--- a/frontend/components/StrategyAllocationPie.tsx
+++ b/frontend/components/StrategyAllocationPie.tsx
@@ -69,7 +69,7 @@ export function StrategyAllocationPie() {
 
     if (isLoading) {
         return (
-            <div className="flex items-center justify-center min-h-[300px]">
+            <div className="flex items-center justify-center min-h-48 sm:min-h-56 md:min-h-[300px]">
                 <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full"></div>
             </div>
         );
@@ -87,7 +87,7 @@ export function StrategyAllocationPie() {
     };
 
     return (
-        <div className="w-full h-[300px] mt-4">
+        <div className="w-full h-48 sm:h-56 md:h-[300px] mt-4">
             <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
                     <Pie

--- a/frontend/components/charts/VaultAPYChart.tsx
+++ b/frontend/components/charts/VaultAPYChart.tsx
@@ -43,15 +43,15 @@ export function VaultAPYChart({ vaultId }: VaultAPYChartProps) {
 
   if (loading) {
     return (
-      <div className="w-full h-[400px] flex items-center justify-center bg-card/50 rounded-xl border border-border animate-pulse">
+      <div className="w-full h-72 sm:h-80 md:h-96 lg:h-[400px] flex items-center justify-center bg-card/50 rounded-xl border border-border animate-pulse">
         <p className="text-muted-foreground">Loading historical data...</p>
       </div>
     );
   }
 
   return (
-    <div className="w-full h-[400px] p-4 bg-card rounded-xl border border-border shadow-sm">
-      <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6 gap-4 md:gap-0">
+    <div className="w-full h-72 sm:h-80 md:h-96 lg:h-[400px] p-4 bg-card rounded-xl border border-border shadow-sm">
+      <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-4 md:mb-6 gap-3 md:gap-4">
         <div>
           <h3 className="text-lg font-semibold text-foreground">Vault Performance</h3>
           <p className="text-sm text-muted-foreground">Historical share price</p>
@@ -71,7 +71,7 @@ export function VaultAPYChart({ vaultId }: VaultAPYChartProps) {
             </button>
           ))}
         </div>
-        <div className="text-right">
+        <div className="text-left md:text-right">
           <span className="text-2xl font-bold text-primary">
             +{( ((data[data.length-1]?.price || 0) / (data[0]?.price || 1) - 1) * 100 ).toFixed(2)}%
           </span>

--- a/frontend/components/transactions/TransactionHistoryList.tsx
+++ b/frontend/components/transactions/TransactionHistoryList.tsx
@@ -47,7 +47,7 @@ export function TransactionHistoryList() {
 
   return (
     <div className="bg-card border border-border p-6 rounded-2xl">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 gap-3">
         <h3 className="font-bold flex items-center gap-2">
           <ArrowDownUp className="w-4 h-4 text-primary" />
           Recent Transactions
@@ -56,11 +56,11 @@ export function TransactionHistoryList() {
           <div className="flex items-center gap-4">
             <button
               onClick={handleExportCSV}
-              className="text-sm px-3 py-1 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/80 flex items-center gap-2 transition-colors"
+              className="text-xs sm:text-sm px-3 py-1 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/80 flex items-center gap-2 transition-colors"
               aria-label="Download CSV"
             >
-              <Download className="w-4 h-4" />
-              Download CSV
+              <Download className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
+              CSV
             </button>
             <button
               onClick={refresh}

--- a/frontend/components/transactions/TransactionHistoryRow.tsx
+++ b/frontend/components/transactions/TransactionHistoryRow.tsx
@@ -44,21 +44,21 @@ export function TransactionHistoryRow({ tx }: TransactionHistoryRowProps) {
   const sign = isDeposit ? "+" : "−";
 
   return (
-    <div className="flex items-center gap-3 py-2.5 border-b border-border last:border-0">
+    <div className="flex items-center gap-2 sm:gap-3 py-2.5 border-b border-border last:border-0">
       <div
-        className={`w-9 h-9 rounded-lg flex items-center justify-center shrink-0 ${iconBg}`}
+        className={`w-8 h-8 sm:w-9 sm:h-9 rounded-lg flex items-center justify-center shrink-0 ${iconBg}`}
       >
-        <Icon className={`w-4 h-4 ${iconColor}`} />
+        <Icon className={`w-3.5 h-3.5 sm:w-4 sm:h-4 ${iconColor}`} />
       </div>
 
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-semibold leading-tight">{kindLabel}</p>
-        <p className="text-[11px] text-muted-foreground truncate">
+        <p className="text-xs sm:text-sm font-semibold leading-tight">{kindLabel}</p>
+        <p className="text-[10px] sm:text-[11px] text-muted-foreground truncate">
           {shortenHash(tx.txHash)} &middot; {formatTimestamp(tx.timestampISO)}
         </p>
       </div>
 
-      <p className={`text-sm font-bold tabular-nums whitespace-nowrap ${amountColor}`}>
+      <p className={`text-xs sm:text-sm font-bold tabular-nums whitespace-nowrap shrink-0 ${amountColor}`}>
         {sign}{formatAmount(tx.amount)} {tx.asset}
       </p>
     </div>


### PR DESCRIPTION
## Summary

- Added a mobile hamburger menu with slide-out drawer for full navigation access on smartphones
- Made header action buttons responsive (compact on small screens, Deposit/Withdraw accessible via drawer)
- Fixed chart heights to use responsive breakpoints (h-72 sm:h-80 md:h-96 lg:h-[400px])
- Fixed ReferralLinkCard input+button to stack vertically on mobile
- Fixed TransactionHistoryRow and TransactionHistoryList to not overflow on narrow screens
- Fixed Settings page currency selector layout for mobile
- Fixed Vault details page with responsive gaps and font sizes
- Fixed AiInsightStream to use theme CSS variables instead of hardcoded dark colors (works in light mode now)
- Fixed RiskChart preserveAspectRatio from "none" to "xMidYMid meet" to prevent distortion
- Added explicit viewport meta tag for proper mobile scaling
- Improved date label truncation on RiskChart for small screens

## Verification
- `npm install --legacy-peer-deps` passes
- `npm run build` compiles successfully with zero errors

Closes #60

@bbkenny