### PR TITLE
Fe 42b keyboard screen reader a11y

### DIFF
--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -38,6 +38,9 @@ export default function Home() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { formatAmount } = useCurrency();
 
+  const focusVisibleClass =
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
   useEffect(() => {
     setMobileMenuOpen(false);
   }, [activeTab]);
@@ -49,13 +52,16 @@ export default function Home() {
       {/* Mobile Menu Overlay */}
       {mobileMenuOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 md:hidden"
+          className="fixed inset-0 bg-black/50 z-40 md:hidden" aria-hidden="true"
           onClick={closeMobileMenu}
         />
       )}
 
       {/* Mobile Menu Drawer */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Mobile navigation menu"
         className={`fixed top-0 right-0 h-full w-64 bg-card border-l border-border z-50 transform transition-transform duration-300 ease-in-out md:hidden ${
           mobileMenuOpen ? "translate-x-0" : "translate-x-full"
         }`}
@@ -63,8 +69,9 @@ export default function Home() {
         <div className="flex items-center justify-between p-4 border-b border-border">
           <span className="font-bold text-lg">Menu</span>
           <button
+            type="button"
             onClick={closeMobileMenu}
-            className="p-2 hover:bg-muted rounded-lg transition-colors"
+            className={`p-2 hover:bg-muted rounded-lg transition-colors ${focusVisibleClass}`}
             aria-label="Close menu"
           >
             <X className="w-5 h-5" />
@@ -83,15 +90,17 @@ export default function Home() {
                 key={item.key}
                 href={item.href}
                 onClick={closeMobileMenu}
-                className="w-full text-left px-4 py-3 rounded-xl text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                className={`w-full text-left px-4 py-3 rounded-xl text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors ${focusVisibleClass}`}
               >
                 {item.label}
               </Link>
             ) : (
               <button
                 key={item.key}
+                type="button"
+                aria-pressed={activeTab === item.key}
                 onClick={() => { setActiveTab(item.key); }}
-                className={`w-full text-left px-4 py-3 rounded-xl text-sm font-medium transition-colors ${activeTab === item.key ? "bg-primary/10 text-primary" : "text-muted-foreground hover:bg-accent hover:text-foreground"}`}
+                className={`w-full text-left px-4 py-3 rounded-xl text-sm font-medium transition-colors ${focusVisibleClass} ${activeTab === item.key ? "bg-primary/10 text-primary" : "text-muted-foreground hover:bg-accent hover:text-foreground"}`}
               >
                 {item.label}
               </button>
@@ -102,14 +111,18 @@ export default function Home() {
               <CurrencySwitch />
             </div>
             <button
+              type="button"
+              aria-pressed={activeTab === "deposit"}
               onClick={() => setActiveTab("deposit")}
-              className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-semibold transition-all ${activeTab === "deposit" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
+              className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-semibold transition-all ${focusVisibleClass} ${activeTab === "deposit" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
             >
               {t('deposit')}
             </button>
             <button
+              type="button"
+              aria-pressed={activeTab === "withdraw"}
               onClick={() => setActiveTab("withdraw")}
-              className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-semibold transition-all ${activeTab === "withdraw" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
+              className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-semibold transition-all ${focusVisibleClass} ${activeTab === "withdraw" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
             >
               {t('withdraw')}
             </button>
@@ -127,42 +140,51 @@ export default function Home() {
             <span className="text-lg sm:text-xl font-bold tracking-tight">X-Aegis</span>
           </div>
           <nav className="hidden md:flex gap-8 text-sm font-medium text-muted-foreground">
-            <button 
+            <button
+              type="button"
+              aria-pressed={activeTab === "dashboard"}
               onClick={() => setActiveTab("dashboard")}
-              className={`${activeTab === "dashboard" ? "text-foreground" : "hover:text-foreground"} transition-colors`}
+              className={`${activeTab === "dashboard" ? "text-foreground" : "hover:text-foreground"} transition-colors rounded-sm ${focusVisibleClass}`}
             >
               {t('dashboard')}
             </button>
-            <button 
+            <button
+              type="button"
+              aria-pressed={activeTab === "referrals"}
               onClick={() => setActiveTab("referrals")}
-              className={`${activeTab === "referrals" ? "text-foreground" : "hover:text-foreground"} transition-colors`}
+              className={`${activeTab === "referrals" ? "text-foreground" : "hover:text-foreground"} transition-colors rounded-sm ${focusVisibleClass}`}
              >
               {t('referrals')}
             </button>
-            <Link href="#" className="hover:text-foreground transition-colors">{t('vaults')}</Link>
-            <Link href="#" className="hover:text-foreground transition-colors">{t('swap')}</Link>
-            <Link href="/settings" className="hover:text-foreground transition-colors">{t('settings')}</Link>
+            <button type="button" className={`hover:text-foreground transition-colors rounded-sm ${focusVisibleClass}`}>{t('vaults')}</button>
+            <button type="button" className={`hover:text-foreground transition-colors rounded-sm ${focusVisibleClass}`}>{t('swap')}</button>
+            <Link href="/settings" className={`hover:text-foreground transition-colors rounded-sm ${focusVisibleClass}`}>{t('settings')}</Link>
           </nav>
           <div className="flex items-center gap-2 sm:gap-4">
             <CurrencySwitch />
             <button
+              type="button"
+              aria-pressed={activeTab === "deposit"}
               onClick={() => setActiveTab("deposit")}
-              className={`hidden sm:inline-flex px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold transition-all ${activeTab === "deposit" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
+              className={`hidden sm:inline-flex px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold transition-all ${focusVisibleClass} ${activeTab === "deposit" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
             >
               {t('deposit')}
             </button>
             <button
+              type="button"
+              aria-pressed={activeTab === "withdraw"}
               onClick={() => setActiveTab("withdraw")}
-              className={`hidden sm:inline-flex px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold transition-all ${activeTab === "withdraw" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
+              className={`hidden sm:inline-flex px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold transition-all ${focusVisibleClass} ${activeTab === "withdraw" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
             >
               {t('withdraw')}
             </button>
-            <button className="bg-primary text-primary-foreground px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold hover:bg-primary/90 transition-all shadow-lg shadow-primary/20 whitespace-nowrap">
+            <button type="button" className={`bg-primary text-primary-foreground px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold hover:bg-primary/90 transition-all shadow-lg shadow-primary/20 whitespace-nowrap ${focusVisibleClass}`}>
               {t('connectWallet')}
             </button>
             <button
+              type="button"
               onClick={() => setMobileMenuOpen(true)}
-              className="md:hidden p-2 hover:bg-muted rounded-lg transition-colors"
+              className={`md:hidden p-2 hover:bg-muted rounded-lg transition-colors ${focusVisibleClass}`}
               aria-label="Open menu"
             >
               <Menu className="w-5 h-5" />
@@ -230,7 +252,7 @@ export default function Home() {
                             <p className="text-[10px] text-muted-foreground uppercase font-bold">Current APY</p>
                             <p className="text-2xl font-bold text-green-500">12.4%</p>
                          </div>
-                         <Link href="/vaults/1" className="text-primary text-sm font-bold flex items-center gap-1">
+                         <Link href="/vaults/1" className={`text-primary text-sm font-bold flex items-center gap-1 rounded-sm ${focusVisibleClass}`}>
                             View Details
                          </Link>
                       </div>
@@ -250,7 +272,7 @@ export default function Home() {
                             <p className="text-[10px] text-muted-foreground uppercase font-bold">Current APY</p>
                             <p className="text-2xl font-bold text-green-500">24.8%</p>
                          </div>
-                         <Link href="/vaults/2" className="text-primary text-sm font-bold flex items-center gap-1">
+                         <Link href="/vaults/2" className={`text-primary text-sm font-bold flex items-center gap-1 rounded-sm ${focusVisibleClass}`}>
                             View Details
                          </Link>
                       </div>
@@ -265,7 +287,7 @@ export default function Home() {
                    <div className="relative z-10">
                       <h2 className="text-2xl font-bold mb-2">Aegis Guard</h2>
                       <p className="text-primary-foreground/80 text-sm mb-6">Your capital is shielded against 98.4% of forecasted volatility.</p>
-                      <button className="w-full bg-background/20 backdrop-blur-md border border-white/20 py-3 rounded-xl font-bold hover:bg-background/30 transition-all uppercase tracking-widest text-xs">
+                      <button type="button" className={`w-full bg-background/20 backdrop-blur-md border border-white/20 py-3 rounded-xl font-bold hover:bg-background/30 transition-all uppercase tracking-widest text-xs ${focusVisibleClass}`}>
                         Configure Shield
                       </button>
                    </div>
@@ -345,3 +367,6 @@ export default function Home() {
     </main>
   );
 }
+
+
+

--- a/frontend/app/[locale]/settings/page.test.tsx
+++ b/frontend/app/[locale]/settings/page.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import SettingsPage from "./page";
+
+describe("SettingsPage accessibility", () => {
+  it("provides an accessible name for the back navigation link", () => {
+    render(<SettingsPage />);
+
+    expect(
+      screen.getByRole("link", { name: /back to dashboard/i })
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("exposes the notification toggle as a keyboard-accessible switch", () => {
+    render(<SettingsPage />);
+
+    const notificationSwitch = screen.getByRole("switch", {
+      name: /toggle push notifications/i,
+    });
+
+    expect(notificationSwitch).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(notificationSwitch);
+
+    expect(notificationSwitch).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("marks the selected appearance theme with aria-pressed", () => {
+    render(<SettingsPage />);
+
+    const systemThemeButton = screen.getByRole("button", { name: /system/i });
+    const lightThemeButton = screen.getByRole("button", { name: /light/i });
+
+    expect(systemThemeButton).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(lightThemeButton);
+
+    expect(lightThemeButton).toHaveAttribute("aria-pressed", "true");
+    expect(systemThemeButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders settings actions as keyboard-reachable buttons and links", () => {
+    render(<SettingsPage />);
+
+    expect(screen.getByRole("button", { name: /general profile/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /security & keys/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /volatility alerts/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /rebalance success/i })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: /view on stellar\.expert/i })
+    ).toHaveAttribute("target", "_blank");
+  });
+});

--- a/frontend/app/[locale]/settings/page.tsx
+++ b/frontend/app/[locale]/settings/page.tsx
@@ -2,14 +2,14 @@
 
 import React, { useState } from 'react';
 import Link from 'next/link';
-import { 
-  Bell, 
-  Shield, 
-  Moon, 
-  Sun, 
-  Monitor, 
-  ChevronRight, 
-  LogOut, 
+import {
+  Bell,
+  Shield,
+  Moon,
+  Sun,
+  Monitor,
+  ChevronRight,
+  LogOut,
   ArrowLeft,
   User,
   Globe,
@@ -22,13 +22,20 @@ export default function SettingsPage() {
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system');
   const [currency, setCurrency] = useState('USD');
 
+  const focusVisibleClass =
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col">
       {/* Header */}
       <header className="border-b border-border bg-card/30 backdrop-blur-md sticky top-0 z-50">
         <div className="container mx-auto px-6 h-16 flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <Link href="/" className="p-2 hover:bg-accent rounded-full transition-colors">
+            <Link
+              href="/"
+              aria-label="Back to dashboard"
+              className={`p-2 hover:bg-accent rounded-full transition-colors ${focusVisibleClass}`}
+            >
               <ArrowLeft className="w-5 h-5" />
             </Link>
             <h1 className="text-xl font-bold">Account Settings</h1>
@@ -44,25 +51,41 @@ export default function SettingsPage() {
       <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8 flex-1 max-w-4xl">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Sidebar */}
-          <aside className="space-y-1">
-            <button className="w-full flex items-center gap-3 px-4 py-3 bg-primary/10 text-primary rounded-xl font-medium text-sm transition-all border border-primary/20">
+          <aside className="space-y-1" aria-label="Settings sections">
+            <button
+              type="button"
+              aria-current="page"
+              className={`w-full flex items-center gap-3 px-4 py-3 bg-primary/10 text-primary rounded-xl font-medium text-sm transition-all border border-primary/20 ${focusVisibleClass}`}
+            >
               <User className="w-4 h-4" />
               General Profile
             </button>
-            <button className="w-full flex items-center gap-3 px-4 py-3 text-muted-foreground hover:bg-accent rounded-xl font-medium text-sm transition-all">
+            <button
+              type="button"
+              className={`w-full flex items-center gap-3 px-4 py-3 text-muted-foreground hover:bg-accent rounded-xl font-medium text-sm transition-all ${focusVisibleClass}`}
+            >
               <Shield className="w-4 h-4" />
               Security & Keys
             </button>
-            <button className="w-full flex items-center gap-3 px-4 py-3 text-muted-foreground hover:bg-accent rounded-xl font-medium text-sm transition-all">
+            <button
+              type="button"
+              className={`w-full flex items-center gap-3 px-4 py-3 text-muted-foreground hover:bg-accent rounded-xl font-medium text-sm transition-all ${focusVisibleClass}`}
+            >
               <Bell className="w-4 h-4" />
               Notifications
             </button>
-            <button className="w-full flex items-center gap-3 px-4 py-3 text-muted-foreground hover:bg-accent rounded-xl font-medium text-sm transition-all">
+            <button
+              type="button"
+              className={`w-full flex items-center gap-3 px-4 py-3 text-muted-foreground hover:bg-accent rounded-xl font-medium text-sm transition-all ${focusVisibleClass}`}
+            >
               <Globe className="w-4 h-4" />
               Regional Settings
             </button>
             <div className="pt-4 mt-4 border-t border-border">
-              <button className="w-full flex items-center gap-3 px-4 py-3 text-rose-500 hover:bg-rose-500/10 rounded-xl font-medium text-sm transition-all">
+              <button
+                type="button"
+                className={`w-full flex items-center gap-3 px-4 py-3 text-rose-500 hover:bg-rose-500/10 rounded-xl font-medium text-sm transition-all ${focusVisibleClass}`}
+              >
                 <LogOut className="w-4 h-4" />
                 Disconnect Wallet
               </button>
@@ -74,46 +97,52 @@ export default function SettingsPage() {
             {/* Preferences Section */}
             <section className="bg-card border border-border rounded-2xl overflow-hidden shadow-sm">
               <div className="p-6 border-b border-border bg-accent/30">
-                <h3 className="font-bold flex items-center gap-2">
+                <h2 className="font-bold flex items-center gap-2">
                   <Monitor className="w-4 h-4 text-primary" />
                   Display Preferences
-                </h3>
+                </h2>
               </div>
               <div className="p-6 space-y-6">
                 {/* Theme Selector */}
-                <div className="space-y-3">
-                  <label className="text-xs font-bold uppercase tracking-widest text-muted-foreground">Appearance Theme</label>
+                <fieldset className="space-y-3">
+                  <legend className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+                    Appearance Theme
+                  </legend>
                   <div className="grid grid-cols-3 gap-3">
                     {[
                       { id: 'light', icon: Sun, label: 'Light' },
                       { id: 'dark', icon: Moon, label: 'Dark' },
                       { id: 'system', icon: Monitor, label: 'System' }
-                    ].map((t) => (
+                    ].map((themeOption) => (
                       <button
-                        key={t.id}
-                        onClick={() => setTheme(t.id as any)}
-                        className={`flex flex-col items-center gap-2 p-3 rounded-xl border transition-all ${theme === t.id ? 'bg-primary/5 border-primary text-primary shadow-sm' : 'hover:bg-accent border-border text-muted-foreground'}`}
+                        key={themeOption.id}
+                        type="button"
+                        aria-pressed={theme === themeOption.id}
+                        onClick={() => setTheme(themeOption.id as 'light' | 'dark' | 'system')}
+                        className={`flex flex-col items-center gap-2 p-3 rounded-xl border transition-all ${focusVisibleClass} ${theme === themeOption.id ? 'bg-primary/5 border-primary text-primary shadow-sm' : 'hover:bg-accent border-border text-muted-foreground'}`}
                       >
-                        <t.icon className="w-5 h-5" />
-                        <span className="text-xs font-medium">{t.label}</span>
+                        <themeOption.icon className="w-5 h-5" />
+                        <span className="text-xs font-medium">{themeOption.label}</span>
                       </button>
                     ))}
                   </div>
-                </div>
+                </fieldset>
 
                 {/* Currency Selector */}
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between pt-2 gap-3 sm:gap-0">
                   <div className="space-y-1">
-                    <p className="font-semibold text-sm flex items-center gap-2">
+                    <label htmlFor="secondary-currency" className="font-semibold text-sm flex items-center gap-2">
                       <Coins className="w-4 h-4 text-muted-foreground" />
                       Secondary Currency
-                    </p>
+                    </label>
                     <p className="text-xs text-muted-foreground">Choose currency for portfolio estimates.</p>
                   </div>
-                  <select 
-                    value={currency} 
+                  <select
+                    id="secondary-currency"
+                    name="secondary-currency"
+                    value={currency}
                     onChange={(e) => setCurrency(e.target.value)}
-                    className="bg-accent/50 border border-border rounded-lg text-sm px-3 py-1.5 focus:ring-1 focus:ring-primary outline-none w-full sm:w-auto"
+                    className={`bg-accent/50 border border-border rounded-lg text-sm px-3 py-1.5 outline-none w-full sm:w-auto ${focusVisibleClass}`}
                   >
                     <option value="USD">USD (Global)</option>
                     <option value="NGN">NGN (Nigeria)</option>
@@ -127,32 +156,48 @@ export default function SettingsPage() {
             {/* Notifications Section */}
             <section className="bg-card border border-border rounded-2xl overflow-hidden shadow-sm">
               <div className="p-6 border-b border-border bg-accent/30 flex justify-between items-center">
-                <h3 className="font-bold flex items-center gap-2">
+                <h2 className="font-bold flex items-center gap-2">
                   <Bell className="w-4 h-4 text-primary" />
                   Push Notifications
-                </h3>
-                <div 
-                  className={`w-12 h-6 rounded-full p-1 cursor-pointer transition-colors duration-200 ease-in-out ${notifications ? 'bg-primary' : 'bg-muted'}`}
+                </h2>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={notifications}
+                  aria-label="Toggle push notifications"
                   onClick={() => setNotifications(!notifications)}
+                  className={`w-12 h-6 rounded-full p-1 transition-colors duration-200 ease-in-out ${focusVisibleClass} ${notifications ? 'bg-primary' : 'bg-muted'}`}
                 >
-                  <div className={`w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform duration-200 ease-in-out ${notifications ? 'translate-x-6' : 'translate-x-0'}`} />
-                </div>
+                  <span className="sr-only">
+                    {notifications ? 'Disable push notifications' : 'Enable push notifications'}
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    className={`block w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform duration-200 ease-in-out ${notifications ? 'translate-x-6' : 'translate-x-0'}`}
+                  />
+                </button>
               </div>
               <div className="p-6 space-y-4">
-                <div className="flex justify-between items-center group cursor-pointer">
-                  <div>
-                    <p className="text-sm font-medium">Volatility Alerts</p>
-                    <p className="text-xs text-muted-foreground italic">Alerts when AI forecasts high risk.</p>
-                  </div>
+                <button
+                  type="button"
+                  className={`w-full flex justify-between items-center group text-left rounded-lg ${focusVisibleClass}`}
+                >
+                  <span>
+                    <span className="block text-sm font-medium">Volatility Alerts</span>
+                    <span className="block text-xs text-muted-foreground italic">Alerts when AI forecasts high risk.</span>
+                  </span>
                   <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
-                </div>
-                <div className="flex justify-between items-center group cursor-pointer pt-2 border-t border-border/50">
-                  <div>
-                    <p className="text-sm font-medium">Rebalance Success</p>
-                    <p className="text-xs text-muted-foreground italic">Confirmations of automated shield actions.</p>
-                  </div>
+                </button>
+                <button
+                  type="button"
+                  className={`w-full flex justify-between items-center group text-left pt-2 border-t border-border/50 rounded-lg ${focusVisibleClass}`}
+                >
+                  <span>
+                    <span className="block text-sm font-medium">Rebalance Success</span>
+                    <span className="block text-xs text-muted-foreground italic">Confirmations of automated shield actions.</span>
+                  </span>
                   <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
-                </div>
+                </button>
               </div>
             </section>
 
@@ -167,7 +212,14 @@ export default function SettingsPage() {
                   <p className="text-xs font-mono text-muted-foreground">GC...4X9S</p>
                 </div>
               </div>
-              <button className="text-xs font-bold text-primary hover:underline">View on Stellar.Expert</button>
+              <a
+                href="https://stellar.expert/explorer/testnet"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`text-xs font-bold text-primary hover:underline rounded-sm ${focusVisibleClass}`}
+              >
+                View on Stellar.Expert
+              </a>
             </section>
           </div>
         </div>


### PR DESCRIPTION
Title:
Improve keyboard navigation and screen reader accessibility

Body:
Closes #83

## Summary

* Improved keyboard accessibility on the main navigation and mobile menu.
* Added clearer focus-visible states for interactive controls.
* Improved settings page accessibility with semantic controls, labels, switch state, and pressed state.
* Added accessibility-focused tests for the settings page.

## Verification

* `npm test` — passed, 35 tests
* `npm run build` — passed

## Notes

* `npm run lint` is currently blocked by the existing `next lint` script issue in this project.
* Build warnings about multiple lockfiles and deprecated middleware convention appear to be existing project warnings, not related to this PR.
