### PR TITLE
[FE-39] Stale Data Indicators & Graceful Degradation

### DIFF
--- a/frontend/components/DataFetchBoundary.tsx
+++ b/frontend/components/DataFetchBoundary.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DataFetchBoundaryProps {
+  children: ReactNode;
+  isLoading: boolean;
+  error: string | null;
+  hasData: boolean;
+  onRetry?: () => void;
+  skeleton?: ReactNode;
+  className?: string;
+}
+
+export function DataFetchBoundary({
+  children,
+  isLoading,
+  error,
+  hasData,
+  onRetry,
+  skeleton,
+  className,
+}: DataFetchBoundaryProps) {
+  if (isLoading && !hasData) {
+    if (skeleton) {
+      return <>{skeleton}</>;
+    }
+    return <DefaultSkeleton className={className} />;
+  }
+
+  if (error && !hasData) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col items-center justify-center gap-4 rounded-2xl border border-destructive/30 bg-destructive/5 p-8",
+          className,
+        )}
+        role="alert"
+      >
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+          <AlertTriangle className="h-6 w-6 text-destructive" />
+        </div>
+        <div className="text-center">
+          <p className="font-semibold text-foreground">Failed to load data</p>
+          <p className="mt-1 text-sm text-muted-foreground">{error}</p>
+        </div>
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+function DefaultSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-4 rounded-2xl border border-border bg-card p-6",
+        className,
+      )}
+      aria-busy="true"
+      aria-label="Loading data"
+    >
+      <div className="h-4 w-1/3 animate-pulse rounded bg-muted" />
+      <div className="h-8 w-1/2 animate-pulse rounded bg-muted" />
+      <div className="h-3 w-full animate-pulse rounded bg-muted" />
+      <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+    </div>
+  );
+}

--- a/frontend/components/StaleDataIndicator.tsx
+++ b/frontend/components/StaleDataIndicator.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { Clock, AlertTriangle, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { type FreshnessLevel } from "@/hooks/useStaleData";
+
+interface StaleDataIndicatorProps {
+  freshnessLevel: FreshnessLevel;
+  lastUpdatedLabel: string;
+  className?: string;
+}
+
+const freshnessConfig: Record<FreshnessLevel, { bg: string; text: string; dot: string; label: string }> = {
+  fresh: {
+    bg: "bg-emerald-500/10",
+    text: "text-emerald-500",
+    dot: "bg-emerald-500",
+    label: "Live",
+  },
+  aging: {
+    bg: "bg-yellow-500/10",
+    text: "text-yellow-600 dark:text-yellow-400",
+    dot: "bg-yellow-500",
+    label: "Aging",
+  },
+  stale: {
+    bg: "bg-red-500/10",
+    text: "text-red-600 dark:text-red-400",
+    dot: "bg-red-500",
+    label: "Stale",
+  },
+};
+
+export function StaleDataIndicator({
+  freshnessLevel,
+  lastUpdatedLabel,
+  className,
+}: StaleDataIndicatorProps) {
+  const config = freshnessConfig[freshnessLevel];
+  const Icon = freshnessLevel === "stale" ? AlertTriangle : Clock;
+
+  if (!lastUpdatedLabel) return null;
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium",
+        config.bg,
+        config.text,
+        className,
+      )}
+      role="status"
+      aria-label={`Data freshness: ${config.label}. ${lastUpdatedLabel}`}
+    >
+      <div className={cn("h-1.5 w-1.5 rounded-full", config.dot)} />
+      <Icon className="h-3 w-3" />
+      <span>{lastUpdatedLabel}</span>
+    </div>
+  );
+}

--- a/frontend/hooks/useStaleData.ts
+++ b/frontend/hooks/useStaleData.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+
+/**
+ * Tracks when data was last fetched and whether it is considered stale.
+ *
+ * @example
+ * const { lastFetchedAt, isStale, freshnessLevel, markFetched } = useStaleData();
+ * // After a successful fetch:
+ * markFetched();
+ */
+export type FreshnessLevel = "fresh" | "aging" | "stale";
+
+const STALE_AGING_THRESHOLD_MS = 60_000; // 60 seconds → yellow
+const STALE_THRESHOLD_MS = 300_000; // 300 seconds (5 min) → red
+
+export interface UseStaleDataResult {
+  lastFetchedAt: Date | null;
+  /** Milliseconds since last fetch, or null if never fetched. */
+  msSinceLastFetch: number | null;
+  isStale: boolean;
+  isAging: boolean;
+  freshnessLevel: FreshnessLevel;
+  /** Call after a successful data fetch. */
+  markFetched: () => void;
+  /** Format "Last updated X minutes ago" or empty string if never fetched. */
+  lastUpdatedLabel: string;
+}
+
+export function useStaleData(): UseStaleDataResult {
+  const [lastFetchedAt, setLastFetchedAt] = useState<Date | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [, forceRerender] = useState(0);
+
+  const markFetched = useCallback(() => {
+    const now = new Date();
+    setLastFetchedAt(now);
+  }, []);
+
+  // Poll every 10 seconds to update the "X minutes ago" label
+  const startTicking = useCallback(() => {
+    if (intervalRef.current) return;
+    intervalRef.current = setInterval(() => {
+      forceRerender((n) => n + 1);
+    }, 10_000);
+  }, []);
+
+  if (lastFetchedAt !== null && !intervalRef.current) {
+    startTicking();
+  }
+
+  const msSinceLastFetch =
+    lastFetchedAt !== null ? Date.now() - lastFetchedAt.getTime() : null;
+
+  const isAging = msSinceLastFetch !== null && msSinceLastFetch > STALE_AGING_THRESHOLD_MS;
+  const isStale = msSinceLastFetch !== null && msSinceLastFetch > STALE_THRESHOLD_MS;
+
+  const freshnessLevel: FreshnessLevel = isStale
+    ? "stale"
+    : isAging
+      ? "aging"
+      : "fresh";
+
+  const lastUpdatedLabel = lastFetchedAt
+    ? formatRelativeTime(lastFetchedAt)
+    : "";
+
+  return {
+    lastFetchedAt,
+    msSinceLastFetch,
+    isStale,
+    isAging,
+    freshnessLevel,
+    markFetched,
+    lastUpdatedLabel,
+  };
+}
+
+function formatRelativeTime(date: Date): string {
+  const ms = Date.now() - date.getTime();
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+
+  if (seconds < 5) return "Just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  if (minutes === 1) return "1 minute ago";
+  if (minutes < 60) return `${minutes} minutes ago`;
+  if (hours === 1) return "1 hour ago";
+  return `${hours} hours ago`;
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -24,5 +24,19 @@
     "waitingForWallet": "Please check your wallet to approve the transaction",
     "viewOnExplorer": "View on Explorer",
     "close": "Close"
+  },
+  "StaleData": {
+    "live": "Live",
+    "aging": "Aging",
+    "stale": "Stale",
+    "justNow": "Just now",
+    "secondsAgo": "{seconds}s ago",
+    "minuteAgo": "1 minute ago",
+    "minutesAgo": "{minutes} minutes ago",
+    "hourAgo": "1 hour ago",
+    "hoursAgo": "{hours} hours ago",
+    "failedToLoad": "Failed to load data",
+    "retry": "Retry",
+    "loading": "Loading data"
   }
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -24,5 +24,19 @@
     "waitingForWallet": "Verifique su billetera para aprobar la transacción",
     "viewOnExplorer": "Ver en Explorer",
     "close": "Cerrar"
+  },
+  "StaleData": {
+    "live": "En vivo",
+    "aging": "Antiguo",
+    "stale": "Obsoleto",
+    "justNow": "Ahora mismo",
+    "secondsAgo": "Hace {seconds}s",
+    "minuteAgo": "Hace 1 minuto",
+    "minutesAgo": "Hace {minutes} minutos",
+    "hourAgo": "Hace 1 hora",
+    "hoursAgo": "Hace {hours} horas",
+    "failedToLoad": "Error al cargar datos",
+    "retry": "Reintentar",
+    "loading": "Cargando datos"
   }
 }


### PR DESCRIPTION
## Summary

Adds stale data indicators, freshness tracking, skeleton loading states, and error fallback UI across the dashboard.

### Changes

- **hooks/useStaleData.ts** — New hook tracking lastFetchedAt timestamp, freshnessLevel (fresh < 60s → green, aging < 300s → yellow, stale → red), lastUpdatedLabel with relative time. Auto-polls every 10s.
- **components/StaleDataIndicator.tsx** — Color-coded badge with green/yellow/red dot, clock/alert icon, accessible role="status".
- **components/DataFetchBoundary.tsx** — Loading/error boundary with skeleton placeholder and error card with retry button.
- **i18n** — Freshness labels in English and Spanish (StaleData namespace).

Closes #80

@thebabalola