### PR TITLE
[FE-47b] Notification Center — Event Integration & Push

### DIFF
--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -21,6 +21,7 @@ import { PartnerDashboard } from "../../components/PartnerDashboard";
 import { Gift, HelpCircle } from "lucide-react";
 import { CurrencySwitch } from "../../components/CurrencySwitch";
 import { NetworkSwitch } from "../../components/NetworkSwitch";
+import { NotificationCenter } from "../../components/NotificationCenter";
 import { useCurrency } from "../../contexts/CurrencyContext";
 
 const MOCK_RISK_DATA = [
@@ -180,6 +181,7 @@ export default function Home() {
             <div className="hidden sm:block">
               <NetworkSwitch />
             </div>
+            <NotificationCenter />
             <button
               type="button"
               aria-pressed={activeTab === "deposit"}

--- a/frontend/app/[locale]/settings/page.test.tsx
+++ b/frontend/app/[locale]/settings/page.test.tsx
@@ -1,9 +1,27 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import SettingsPage from "./page";
 
 describe("SettingsPage accessibility", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: {
+        permission: "default",
+        requestPermission: jest.fn().mockResolvedValue("granted"),
+      },
+    });
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        register: jest.fn().mockResolvedValue({}),
+        ready: Promise.resolve({ showNotification: jest.fn() }),
+      },
+    });
+  });
+
   it("provides an accessible name for the back navigation link", () => {
     render(<SettingsPage />);
 
@@ -12,14 +30,21 @@ describe("SettingsPage accessibility", () => {
     ).toHaveAttribute("href", "/");
   });
 
-  it("exposes the notification toggle as a keyboard-accessible switch", () => {
+  it("exposes the notification toggle as a keyboard-accessible switch that opts in on click", async () => {
     render(<SettingsPage />);
 
     const notificationSwitch = screen.getByRole("switch", {
       name: /enable push notifications/i,
     });
 
-    expect(notificationSwitch).toHaveAttribute("aria-checked", "true");
+    // Starts opted out — this is a real opt-in now, not a decorative default.
+    expect(notificationSwitch).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(notificationSwitch);
+
+    await waitFor(() =>
+      expect(notificationSwitch).toHaveAttribute("aria-checked", "true")
+    );
 
     fireEvent.click(notificationSwitch);
 

--- a/frontend/app/[locale]/settings/page.tsx
+++ b/frontend/app/[locale]/settings/page.tsx
@@ -16,11 +16,14 @@ import {
   Wallet,
   Coins
 } from 'lucide-react';
+import { usePushNotifications } from '@/hooks/usePushNotifications';
 
 export default function SettingsPage() {
-  const [notifications, setNotifications] = useState(true);
+  const { optedIn, permission, enable, disable } = usePushNotifications();
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system');
   const [currency, setCurrency] = useState('USD');
+
+  const pushUnavailable = permission === 'unsupported' || permission === 'denied';
 
   const focusVisibleClass =
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background';
@@ -172,20 +175,26 @@ export default function SettingsPage() {
                 <button
                   type="button"
                   role="switch"
-                  aria-checked={notifications}
+                  aria-checked={optedIn}
                   aria-label="Enable push notifications"
-                  onClick={() => setNotifications(!notifications)}
-                  className={`w-12 h-6 rounded-full p-1 transition-colors duration-200 ease-in-out ${focusVisibleClass} ${notifications ? 'bg-primary' : 'bg-muted'}`}
+                  disabled={pushUnavailable}
+                  onClick={() => (optedIn ? disable() : enable())}
+                  className={`w-12 h-6 rounded-full p-1 transition-colors duration-200 ease-in-out ${focusVisibleClass} ${optedIn ? 'bg-primary' : 'bg-muted'} ${pushUnavailable ? 'opacity-50 cursor-not-allowed' : ''}`}
                 >
                   <span className="sr-only">
-                    {notifications ? 'Disable push notifications' : 'Enable push notifications'}
+                    {optedIn ? 'Disable push notifications' : 'Enable push notifications'}
                   </span>
                   <span
                     aria-hidden="true"
-                    className={`block w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform duration-200 ease-in-out ${notifications ? 'translate-x-6' : 'translate-x-0'}`}
+                    className={`block w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform duration-200 ease-in-out ${optedIn ? 'translate-x-6' : 'translate-x-0'}`}
                   />
                 </button>
               </div>
+              {permission === 'denied' && (
+                <p className="px-6 pt-4 text-xs text-muted-foreground">
+                  Notifications are blocked in your browser settings. Allow notifications for this site to enable this.
+                </p>
+              )}
               <div className="p-6 space-y-4">
                 <button
                   type="button"

--- a/frontend/components/NotificationCenter.tsx
+++ b/frontend/components/NotificationCenter.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useCallback } from "react";
 import { Bell, ArrowDownLeft, ArrowUpRight, RefreshCw } from "lucide-react";
 import { useFreighter } from "@/contexts/FreighterContext";
 import { useOnChainNotifications, type NotificationEntry } from "@/hooks/useOnChainNotifications";
+import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { formatRelativeTime } from "@/lib/utils";
 import type { TransactionKind } from "@/types/transactions";
@@ -40,8 +42,22 @@ function NotificationRow({ entry }: { entry: NotificationEntry }) {
 
 export function NotificationCenter() {
   const { address } = useFreighter();
+  const { showNotification } = usePushNotifications();
+
+  const onNewEntries = useCallback(
+    (entries: NotificationEntry[]) => {
+      // Cap it — if a bunch of events land in one poll, showing that many
+      // OS notifications at once is more spam than signal.
+      entries.slice(0, 3).forEach((entry) => {
+        void showNotification(entry.title, entry.message);
+      });
+    },
+    [showNotification]
+  );
+
   const { notifications, unreadCount, markAllRead } = useOnChainNotifications({
     account: address,
+    onNewEntries,
   });
 
   return (

--- a/frontend/components/NotificationCenter.tsx
+++ b/frontend/components/NotificationCenter.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Bell, ArrowDownLeft, ArrowUpRight, RefreshCw } from "lucide-react";
+import { useFreighter } from "@/contexts/FreighterContext";
+import { useOnChainNotifications, type NotificationEntry } from "@/hooks/useOnChainNotifications";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { formatRelativeTime } from "@/lib/utils";
+import type { TransactionKind } from "@/types/transactions";
+
+const KIND_ICON: Record<TransactionKind, typeof Bell> = {
+  DEPOSIT: ArrowDownLeft,
+  WITHDRAW: ArrowUpRight,
+  REBALANCE: RefreshCw,
+};
+
+function NotificationRow({ entry }: { entry: NotificationEntry }) {
+  const Icon = KIND_ICON[entry.kind];
+  return (
+    <div
+      className={`flex items-start gap-2.5 px-3 py-2.5 border-b border-border last:border-0 ${
+        entry.read ? "" : "bg-primary/5"
+      }`}
+    >
+      <div className="w-7 h-7 rounded-lg bg-muted flex items-center justify-center shrink-0 mt-0.5">
+        <Icon className="w-3.5 h-3.5 text-muted-foreground" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-xs font-semibold leading-tight">{entry.title}</p>
+        <p className="text-[11px] text-muted-foreground leading-snug mt-0.5">{entry.message}</p>
+        <p className="text-[10px] text-muted-foreground/70 mt-1">
+          {formatRelativeTime(entry.timestampISO)}
+        </p>
+      </div>
+      {!entry.read && (
+        <span className="w-1.5 h-1.5 rounded-full bg-primary shrink-0 mt-1.5" aria-hidden="true" />
+      )}
+    </div>
+  );
+}
+
+export function NotificationCenter() {
+  const { address } = useFreighter();
+  const { notifications, unreadCount, markAllRead } = useOnChainNotifications({
+    account: address,
+  });
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        className="relative p-2 hover:bg-muted rounded-lg transition-colors"
+        aria-label={unreadCount > 0 ? `Notifications, ${unreadCount} unread` : "Notifications"}
+        onClick={() => {
+          if (unreadCount > 0) markAllRead();
+        }}
+      >
+        <Bell className="w-5 h-5" />
+        {unreadCount > 0 && (
+          <span
+            className="absolute top-1 right-1 min-w-[16px] h-4 px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold flex items-center justify-center"
+            aria-hidden="true"
+          >
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </PopoverTrigger>
+
+      <PopoverContent className="max-h-[400px] overflow-hidden flex flex-col">
+        <div className="px-3 py-2.5 border-b border-border">
+          <p className="text-sm font-bold">Notifications</p>
+        </div>
+
+        <div className="overflow-y-auto flex-1">
+          {notifications.length === 0 ? (
+            <p className="text-xs text-muted-foreground text-center py-8 px-3">
+              No notifications yet
+            </p>
+          ) : (
+            notifications.map((entry) => <NotificationRow key={entry.id} entry={entry} />)
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/components/transactions/TransactionHistoryRow.tsx
+++ b/frontend/components/transactions/TransactionHistoryRow.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowDownLeft, ArrowUpRight, RefreshCw } from "lucide-react";
 import type { TransactionItem, TransactionKind } from "@/types/transactions";
+import { formatRelativeTime } from "@/lib/utils";
 
 const KIND_STYLE: Record<
   TransactionKind,
@@ -37,19 +38,6 @@ interface TransactionHistoryRowProps {
   tx: TransactionItem;
 }
 
-function formatTimestamp(iso: string): string {
-  const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffHrs = Math.floor(diffMs / 3_600_000);
-
-  if (diffHrs < 1) return "Just now";
-  if (diffHrs < 24) return `${diffHrs}h ago`;
-  const diffDays = Math.floor(diffHrs / 24);
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-}
-
 function shortenHash(hash: string): string {
   if (hash.length <= 12) return hash;
   return `${hash.slice(0, 6)}…${hash.slice(-4)}`;
@@ -78,7 +66,7 @@ export function TransactionHistoryRow({ tx }: TransactionHistoryRowProps) {
       <div className="flex-1 min-w-0">
         <p className="text-xs sm:text-sm font-semibold leading-tight">{label}</p>
         <p className="text-[10px] sm:text-[11px] text-muted-foreground truncate">
-          {shortenHash(tx.txHash)} &middot; {formatTimestamp(tx.timestampISO)}
+          {shortenHash(tx.txHash)} &middot; {formatRelativeTime(tx.timestampISO)}
         </p>
       </div>
 

--- a/frontend/components/transactions/TransactionHistoryRow.tsx
+++ b/frontend/components/transactions/TransactionHistoryRow.tsx
@@ -1,7 +1,37 @@
 "use client";
 
-import { ArrowDownLeft, ArrowUpRight } from "lucide-react";
-import type { TransactionItem } from "@/types/transactions";
+import { ArrowDownLeft, ArrowUpRight, RefreshCw } from "lucide-react";
+import type { TransactionItem, TransactionKind } from "@/types/transactions";
+
+const KIND_STYLE: Record<
+  TransactionKind,
+  { Icon: typeof ArrowDownLeft; label: string; iconBg: string; iconColor: string; amountColor: string; sign: string }
+> = {
+  DEPOSIT: {
+    Icon: ArrowDownLeft,
+    label: "Deposit",
+    iconBg: "bg-green-500/10",
+    iconColor: "text-green-500",
+    amountColor: "text-green-500",
+    sign: "+",
+  },
+  WITHDRAW: {
+    Icon: ArrowUpRight,
+    label: "Withdraw",
+    iconBg: "bg-red-500/10",
+    iconColor: "text-red-500",
+    amountColor: "text-red-400",
+    sign: "−",
+  },
+  REBALANCE: {
+    Icon: RefreshCw,
+    label: "Rebalance",
+    iconBg: "bg-blue-500/10",
+    iconColor: "text-blue-500",
+    amountColor: "text-muted-foreground",
+    sign: "",
+  },
+};
 
 interface TransactionHistoryRowProps {
   tx: TransactionItem;
@@ -35,13 +65,7 @@ function formatAmount(amount: string): string {
 }
 
 export function TransactionHistoryRow({ tx }: TransactionHistoryRowProps) {
-  const isDeposit = tx.kind === "DEPOSIT";
-  const Icon = isDeposit ? ArrowDownLeft : ArrowUpRight;
-  const kindLabel = isDeposit ? "Deposit" : "Withdraw";
-  const iconBg = isDeposit ? "bg-green-500/10" : "bg-red-500/10";
-  const iconColor = isDeposit ? "text-green-500" : "text-red-500";
-  const amountColor = isDeposit ? "text-green-500" : "text-red-400";
-  const sign = isDeposit ? "+" : "−";
+  const { Icon, label, iconBg, iconColor, amountColor, sign } = KIND_STYLE[tx.kind];
 
   return (
     <div className="flex items-center gap-2 sm:gap-3 py-2.5 border-b border-border last:border-0">
@@ -52,7 +76,7 @@ export function TransactionHistoryRow({ tx }: TransactionHistoryRowProps) {
       </div>
 
       <div className="flex-1 min-w-0">
-        <p className="text-xs sm:text-sm font-semibold leading-tight">{kindLabel}</p>
+        <p className="text-xs sm:text-sm font-semibold leading-tight">{label}</p>
         <p className="text-[10px] sm:text-[11px] text-muted-foreground truncate">
           {shortenHash(tx.txHash)} &middot; {formatTimestamp(tx.timestampISO)}
         </p>

--- a/frontend/components/ui/popover.tsx
+++ b/frontend/components/ui/popover.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover(props: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger(props: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  side = "bottom",
+  align = "end",
+  sideOffset = 8,
+  ...props
+}: PopoverPrimitive.Popup.Props & PopoverPrimitive.Positioner.Props) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 w-72 rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-lg outline-none",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/frontend/hooks/useOnChainNotifications.test.ts
+++ b/frontend/hooks/useOnChainNotifications.test.ts
@@ -1,0 +1,125 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import { useOnChainNotifications } from "./useOnChainNotifications";
+import type { IndexerEventRaw } from "@/types/transactions";
+
+jest.mock("sonner", () => ({
+  toast: { info: jest.fn() },
+}));
+
+const fetchRecentEvents = jest.fn<Promise<IndexerEventRaw[]>, any[]>();
+jest.mock("@/lib/indexer/transactions", () => ({
+  fetchRecentEvents: (...args: any[]) => fetchRecentEvents(...args),
+}));
+
+function makeRaw(id: string, eventType: string, timestamp: string): IndexerEventRaw {
+  return {
+    id,
+    eventType,
+    txHash: `0x${id}`,
+    timestamp,
+    amount: "10",
+    asset: "USDC",
+    account: "GABC",
+  };
+}
+
+describe("useOnChainNotifications", () => {
+  const ACCOUNT = "GABC";
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_MERCURY_URL = "https://mercury.test";
+    localStorage.clear();
+    fetchRecentEvents.mockReset();
+    (toast.info as jest.Mock).mockReset();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_MERCURY_URL;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not toast for events already present on first load", async () => {
+    fetchRecentEvents.mockResolvedValue([
+      makeRaw("a", "deposit", "2024-01-01T00:00:00.000Z"),
+      makeRaw("b", "withdraw", "2024-01-02T00:00:00.000Z"),
+    ]);
+
+    const { result } = renderHook(() =>
+      useOnChainNotifications({ account: ACCOUNT, pollIntervalMs: 60_000 })
+    );
+
+    await waitFor(() => expect(result.current.notifications).toHaveLength(2));
+
+    expect(toast.info).not.toHaveBeenCalled();
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it("toasts and marks unread for events that show up after the first load", async () => {
+    fetchRecentEvents.mockResolvedValueOnce([makeRaw("a", "deposit", "2024-01-01T00:00:00.000Z")]);
+
+    const { result } = renderHook(() =>
+      useOnChainNotifications({ account: ACCOUNT, pollIntervalMs: 1000 })
+    );
+
+    await waitFor(() => expect(result.current.notifications).toHaveLength(1));
+    expect(toast.info).not.toHaveBeenCalled();
+
+    fetchRecentEvents.mockResolvedValueOnce([
+      makeRaw("a", "deposit", "2024-01-01T00:00:00.000Z"),
+      makeRaw("b", "rebalance", "2024-01-02T00:00:00.000Z"),
+    ]);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.notifications).toHaveLength(2));
+    expect(toast.info).toHaveBeenCalledTimes(1);
+    expect(result.current.unreadCount).toBe(1);
+    expect(result.current.notifications[0].id).toBe("b");
+  });
+
+  it("persists seen events across remounts so a reload doesn't re-toast", async () => {
+    fetchRecentEvents.mockResolvedValue([makeRaw("a", "deposit", "2024-01-01T00:00:00.000Z")]);
+
+    const first = renderHook(() =>
+      useOnChainNotifications({ account: ACCOUNT, pollIntervalMs: 60_000 })
+    );
+    await waitFor(() => expect(first.result.current.notifications).toHaveLength(1));
+    first.unmount();
+
+    const second = renderHook(() =>
+      useOnChainNotifications({ account: ACCOUNT, pollIntervalMs: 60_000 })
+    );
+    await waitFor(() => expect(second.result.current.notifications).toHaveLength(1));
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  it("markAllRead clears unread count", async () => {
+    fetchRecentEvents.mockResolvedValueOnce([makeRaw("a", "deposit", "2024-01-01T00:00:00.000Z")]);
+    const { result } = renderHook(() =>
+      useOnChainNotifications({ account: ACCOUNT, pollIntervalMs: 1000 })
+    );
+    await waitFor(() => expect(result.current.notifications).toHaveLength(1));
+
+    fetchRecentEvents.mockResolvedValueOnce([
+      makeRaw("a", "deposit", "2024-01-01T00:00:00.000Z"),
+      makeRaw("b", "withdraw", "2024-01-02T00:00:00.000Z"),
+    ]);
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.unreadCount).toBe(1));
+
+    act(() => result.current.markAllRead());
+    expect(result.current.unreadCount).toBe(0);
+  });
+});

--- a/frontend/hooks/useOnChainNotifications.ts
+++ b/frontend/hooks/useOnChainNotifications.ts
@@ -30,7 +30,6 @@ interface UseOnChainNotificationsResult {
   clear: () => void;
 }
 
-const MERCURY_URL = process.env.NEXT_PUBLIC_MERCURY_URL;
 const MAX_STORED = 50;
 
 function seenKey(account: string) {
@@ -96,7 +95,7 @@ export function useOnChainNotifications({
 
     let raw: IndexerEventRaw[];
     try {
-      if (MERCURY_URL) {
+      if (process.env.NEXT_PUBLIC_MERCURY_URL) {
         const { fetchRecentEvents } = await import("@/lib/indexer/transactions");
         raw = await fetchRecentEvents({ account, limit });
       } else {

--- a/frontend/hooks/useOnChainNotifications.ts
+++ b/frontend/hooks/useOnChainNotifications.ts
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { toast } from "sonner";
+import type { IndexerEventRaw, TransactionKind } from "@/types/transactions";
+import { normalizeAndSort } from "@/lib/indexer/transactionMappers";
+import { formatEventMessage } from "@/lib/notifications/formatEventMessage";
+import { generateMockEvents } from "@/hooks/useTransactionHistory";
+
+export interface NotificationEntry {
+  id: string;
+  kind: TransactionKind;
+  title: string;
+  message: string;
+  timestampISO: string;
+  read: boolean;
+}
+
+interface UseOnChainNotificationsOptions {
+  account?: string | null;
+  pollIntervalMs?: number;
+  limit?: number;
+  onNewEntries?: (entries: NotificationEntry[]) => void;
+}
+
+interface UseOnChainNotificationsResult {
+  notifications: NotificationEntry[];
+  unreadCount: number;
+  markAllRead: () => void;
+  clear: () => void;
+}
+
+const MERCURY_URL = process.env.NEXT_PUBLIC_MERCURY_URL;
+const MAX_STORED = 50;
+
+function seenKey(account: string) {
+  return `xaegis:notifications:seen:${account}`;
+}
+function listKey(account: string) {
+  return `xaegis:notifications:list:${account}`;
+}
+
+function readJSON<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeJSON(key: string, value: unknown) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // storage full or unavailable — notifications still work for this session
+  }
+}
+
+/**
+ * Polls the indexer for new on-chain events for the connected account,
+ * turns anything not seen before into a NotificationEntry, and toasts it.
+ * Seen event ids and the notification list are persisted per-account so a
+ * reload doesn't replay history as if it just happened, and doesn't lose
+ * what was already surfaced.
+ */
+export function useOnChainNotifications({
+  account,
+  pollIntervalMs = 15_000,
+  limit = 20,
+  onNewEntries,
+}: UseOnChainNotificationsOptions): UseOnChainNotificationsResult {
+  const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
+  const seenIdsRef = useRef<Set<string>>(new Set());
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    initializedRef.current = false;
+    seenIdsRef.current = new Set();
+    setNotifications([]);
+    if (!account) return;
+
+    const storedSeen = readJSON<string[]>(seenKey(account));
+    if (storedSeen) seenIdsRef.current = new Set(storedSeen);
+    const storedList = readJSON<NotificationEntry[]>(listKey(account));
+    if (storedList) setNotifications(storedList);
+  }, [account]);
+
+  const persist = useCallback((acct: string, list: NotificationEntry[]) => {
+    writeJSON(seenKey(acct), [...seenIdsRef.current]);
+    writeJSON(listKey(acct), list.slice(0, MAX_STORED));
+  }, []);
+
+  const poll = useCallback(async () => {
+    if (!account) return;
+
+    let raw: IndexerEventRaw[];
+    try {
+      if (MERCURY_URL) {
+        const { fetchRecentEvents } = await import("@/lib/indexer/transactions");
+        raw = await fetchRecentEvents({ account, limit });
+      } else {
+        raw = generateMockEvents(limit);
+      }
+    } catch {
+      return; // transient fetch failure — the next interval tries again
+    }
+
+    const events = normalizeAndSort(raw);
+    const isFirstLoad = !initializedRef.current;
+    initializedRef.current = true;
+
+    const fresh = events.filter((e) => !seenIdsRef.current.has(e.id));
+    if (fresh.length === 0) return;
+    fresh.forEach((e) => seenIdsRef.current.add(e.id));
+
+    // On first load, mark as already-read — otherwise every reload would
+    // dump the account's whole event history into the notification list as
+    // if it all just happened.
+    const entries: NotificationEntry[] = fresh.map((e) => {
+      const { title, message } = formatEventMessage(e);
+      return {
+        id: e.id,
+        kind: e.kind,
+        title,
+        message,
+        timestampISO: e.timestampISO,
+        read: isFirstLoad,
+      };
+    });
+
+    setNotifications((prev) => {
+      const next = [...entries, ...prev].slice(0, MAX_STORED);
+      persist(account, next);
+      return next;
+    });
+
+    if (!isFirstLoad) {
+      entries.forEach((entry) => {
+        toast.info(entry.title, { description: entry.message });
+      });
+      onNewEntries?.(entries);
+    }
+  }, [account, limit, persist, onNewEntries]);
+
+  useEffect(() => {
+    if (!account) return;
+    poll();
+    const interval = setInterval(poll, pollIntervalMs);
+    return () => clearInterval(interval);
+  }, [account, pollIntervalMs, poll]);
+
+  const markAllRead = useCallback(() => {
+    setNotifications((prev) => {
+      const next = prev.map((n) => ({ ...n, read: true }));
+      if (account) persist(account, next);
+      return next;
+    });
+  }, [account, persist]);
+
+  const clear = useCallback(() => {
+    setNotifications([]);
+    if (account) persist(account, []);
+  }, [account, persist]);
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  return { notifications, unreadCount, markAllRead, clear };
+}

--- a/frontend/hooks/usePushNotifications.test.ts
+++ b/frontend/hooks/usePushNotifications.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { usePushNotifications } from "./usePushNotifications";
+
+describe("usePushNotifications", () => {
+  let requestPermission: jest.Mock;
+  let register: jest.Mock;
+
+  beforeEach(() => {
+    localStorage.clear();
+    requestPermission = jest.fn().mockResolvedValue("granted");
+    register = jest.fn().mockResolvedValue({});
+
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: { permission: "default", requestPermission },
+    });
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: { register, ready: Promise.resolve({ showNotification: jest.fn() }) },
+    });
+  });
+
+  it("starts opted out with default permission", async () => {
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.permission).toBe("default"));
+    expect(result.current.optedIn).toBe(false);
+  });
+
+  it("enable() requests permission, registers the service worker, and opts in", async () => {
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.permission).toBe("default"));
+
+    await act(async () => {
+      await result.current.enable();
+    });
+
+    expect(requestPermission).toHaveBeenCalled();
+    expect(register).toHaveBeenCalledWith("/sw.js");
+    expect(result.current.optedIn).toBe(true);
+    expect(result.current.permission).toBe("granted");
+    expect(localStorage.getItem("xaegis:push-opt-in")).toBe("true");
+  });
+
+  it("does not opt in if permission is denied", async () => {
+    requestPermission.mockResolvedValue("denied");
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.permission).toBe("default"));
+
+    await act(async () => {
+      await result.current.enable();
+    });
+
+    expect(register).not.toHaveBeenCalled();
+    expect(result.current.optedIn).toBe(false);
+    expect(result.current.permission).toBe("denied");
+  });
+
+  it("disable() opts out without touching browser permission", async () => {
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.permission).toBe("default"));
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    expect(result.current.optedIn).toBe(true);
+
+    act(() => result.current.disable());
+    expect(result.current.optedIn).toBe(false);
+    expect(localStorage.getItem("xaegis:push-opt-in")).toBe("false");
+  });
+
+  it("showNotification is a no-op when not opted in", async () => {
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.permission).toBe("default"));
+
+    const registration = await navigator.serviceWorker.ready;
+    await act(async () => {
+      await result.current.showNotification("title", "body");
+    });
+
+    expect((registration as any).showNotification).not.toHaveBeenCalled();
+  });
+
+  it("showNotification calls through to the service worker once opted in", async () => {
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.permission).toBe("default"));
+
+    await act(async () => {
+      await result.current.enable();
+    });
+
+    const registration = await navigator.serviceWorker.ready;
+    await act(async () => {
+      await result.current.showNotification("New deposit", "120 USDC");
+    });
+
+    expect((registration as any).showNotification).toHaveBeenCalledWith(
+      "New deposit",
+      expect.objectContaining({ body: "120 USDC" })
+    );
+  });
+});

--- a/frontend/hooks/usePushNotifications.ts
+++ b/frontend/hooks/usePushNotifications.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const OPT_IN_KEY = "xaegis:push-opt-in";
+
+export type PushPermission = "default" | "granted" | "denied" | "unsupported";
+
+interface UsePushNotificationsResult {
+  /** Whether the user has opted in, independent of browser permission state. */
+  optedIn: boolean;
+  permission: PushPermission;
+  /** Requests permission (if needed), registers the SW, and opts in. */
+  enable: () => Promise<void>;
+  /** Opts out. Browser permission itself can't be revoked from script. */
+  disable: () => void;
+  /** Shows a notification via the registered SW if opted in and permitted. */
+  showNotification: (title: string, body: string) => Promise<void>;
+}
+
+function isSupported(): boolean {
+  return typeof window !== "undefined" && "serviceWorker" in navigator && "Notification" in window;
+}
+
+export function usePushNotifications(): UsePushNotificationsResult {
+  const [optedIn, setOptedIn] = useState(false);
+  const [permission, setPermission] = useState<PushPermission>("default");
+
+  useEffect(() => {
+    if (!isSupported()) {
+      setPermission("unsupported");
+      return;
+    }
+    setPermission(Notification.permission as PushPermission);
+    setOptedIn(localStorage.getItem(OPT_IN_KEY) === "true");
+  }, []);
+
+  const enable = useCallback(async () => {
+    if (!isSupported()) return;
+
+    let result = Notification.permission;
+    if (result === "default") {
+      result = await Notification.requestPermission();
+    }
+    setPermission(result as PushPermission);
+
+    if (result !== "granted") return;
+
+    await navigator.serviceWorker.register("/sw.js");
+    localStorage.setItem(OPT_IN_KEY, "true");
+    setOptedIn(true);
+  }, []);
+
+  const disable = useCallback(() => {
+    localStorage.setItem(OPT_IN_KEY, "false");
+    setOptedIn(false);
+  }, []);
+
+  const showNotification = useCallback(
+    async (title: string, body: string) => {
+      if (!isSupported() || !optedIn || permission !== "granted") return;
+      const registration = await navigator.serviceWorker.ready;
+      await registration.showNotification(title, { body, icon: "/favicon.ico" });
+    },
+    [optedIn, permission]
+  );
+
+  return { optedIn, permission, enable, disable, showNotification };
+}

--- a/frontend/hooks/useTransactionHistory.ts
+++ b/frontend/hooks/useTransactionHistory.ts
@@ -69,7 +69,7 @@ export function useTransactionHistory({
   return { items, loading, error, refresh };
 }
 
-function generateMockEvents(count: number): IndexerEventRaw[] {
+export function generateMockEvents(count: number): IndexerEventRaw[] {
   const assets = ["USDC", "XLM", "EURC"];
   const kinds: Array<{ eventType: string }> = [
     { eventType: "deposit" },

--- a/frontend/hooks/useTransactionHistory.ts
+++ b/frontend/hooks/useTransactionHistory.ts
@@ -74,6 +74,7 @@ function generateMockEvents(count: number): IndexerEventRaw[] {
   const kinds: Array<{ eventType: string }> = [
     { eventType: "deposit" },
     { eventType: "withdraw" },
+    { eventType: "rebalance" },
   ];
 
   const events: IndexerEventRaw[] = [];

--- a/frontend/lib/indexer/transactionMappers.test.ts
+++ b/frontend/lib/indexer/transactionMappers.test.ts
@@ -1,0 +1,68 @@
+import {
+  isDepositEvent,
+  isWithdrawEvent,
+  isRebalanceEvent,
+  toTransactionItem,
+  normalizeAndSort,
+} from "./transactionMappers";
+import type { IndexerEventRaw } from "@/types/transactions";
+
+function makeRaw(overrides: Partial<IndexerEventRaw> = {}): IndexerEventRaw {
+  return {
+    id: "evt-1",
+    eventType: "deposit",
+    txHash: "0xabc",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    amount: "100",
+    asset: "USDC",
+    account: "GABC",
+    ...overrides,
+  };
+}
+
+describe("event type detection", () => {
+  it("recognizes deposit-like event types", () => {
+    expect(isDepositEvent(makeRaw({ eventType: "deposit" }))).toBe(true);
+    expect(isDepositEvent(makeRaw({ eventType: "MINT" }))).toBe(true);
+    expect(isDepositEvent(makeRaw({ eventType: "transfer_in" }))).toBe(true);
+    expect(isDepositEvent(makeRaw({ eventType: "rebalance" }))).toBe(false);
+  });
+
+  it("recognizes withdraw-like event types", () => {
+    expect(isWithdrawEvent(makeRaw({ eventType: "withdraw" }))).toBe(true);
+    expect(isWithdrawEvent(makeRaw({ eventType: "BURN" }))).toBe(true);
+    expect(isWithdrawEvent(makeRaw({ eventType: "transfer_out" }))).toBe(true);
+    expect(isWithdrawEvent(makeRaw({ eventType: "deposit" }))).toBe(false);
+  });
+
+  it("recognizes rebalance-like event types", () => {
+    expect(isRebalanceEvent(makeRaw({ eventType: "rebalance" }))).toBe(true);
+    expect(isRebalanceEvent(makeRaw({ eventType: "REALLOCATE" }))).toBe(true);
+    expect(isRebalanceEvent(makeRaw({ eventType: "strategy_rebalance" }))).toBe(true);
+    expect(isRebalanceEvent(makeRaw({ eventType: "deposit" }))).toBe(false);
+  });
+});
+
+describe("toTransactionItem", () => {
+  it("maps a rebalance event to the REBALANCE kind", () => {
+    const item = toTransactionItem(makeRaw({ eventType: "rebalance" }));
+    expect(item?.kind).toBe("REBALANCE");
+  });
+
+  it("returns null for an unrecognized event type", () => {
+    expect(toTransactionItem(makeRaw({ eventType: "something_else" }))).toBeNull();
+  });
+});
+
+describe("normalizeAndSort", () => {
+  it("drops unrecognized events and sorts recognized ones newest first", () => {
+    const events = [
+      makeRaw({ id: "a", eventType: "deposit", timestamp: "2024-01-01T00:00:00.000Z" }),
+      makeRaw({ id: "b", eventType: "unknown_type", timestamp: "2024-01-03T00:00:00.000Z" }),
+      makeRaw({ id: "c", eventType: "rebalance", timestamp: "2024-01-02T00:00:00.000Z" }),
+    ];
+
+    const result = normalizeAndSort(events);
+    expect(result.map((e) => e.id)).toEqual(["c", "a"]);
+  });
+});

--- a/frontend/lib/indexer/transactionMappers.ts
+++ b/frontend/lib/indexer/transactionMappers.ts
@@ -6,6 +6,7 @@ import type {
 
 const DEPOSIT_TYPES = new Set(["deposit", "mint", "transfer_in"]);
 const WITHDRAW_TYPES = new Set(["withdraw", "burn", "transfer_out"]);
+const REBALANCE_TYPES = new Set(["rebalance", "reallocate", "strategy_rebalance"]);
 
 export function isDepositEvent(raw: IndexerEventRaw): boolean {
   return DEPOSIT_TYPES.has(raw.eventType.toLowerCase());
@@ -15,9 +16,14 @@ export function isWithdrawEvent(raw: IndexerEventRaw): boolean {
   return WITHDRAW_TYPES.has(raw.eventType.toLowerCase());
 }
 
+export function isRebalanceEvent(raw: IndexerEventRaw): boolean {
+  return REBALANCE_TYPES.has(raw.eventType.toLowerCase());
+}
+
 function kindFromEvent(raw: IndexerEventRaw): TransactionKind | null {
   if (isDepositEvent(raw)) return "DEPOSIT";
   if (isWithdrawEvent(raw)) return "WITHDRAW";
+  if (isRebalanceEvent(raw)) return "REBALANCE";
   return null;
 }
 

--- a/frontend/lib/notifications/formatEventMessage.test.ts
+++ b/frontend/lib/notifications/formatEventMessage.test.ts
@@ -1,0 +1,43 @@
+import { formatEventMessage } from "./formatEventMessage";
+import type { TransactionItem } from "@/types/transactions";
+
+function makeItem(overrides: Partial<TransactionItem> = {}): TransactionItem {
+  return {
+    id: "evt-1",
+    kind: "DEPOSIT",
+    txHash: "0xabc",
+    timestampISO: "2024-01-01T00:00:00.000Z",
+    amount: "120.5",
+    asset: "USDC",
+    account: "GABC",
+    ...overrides,
+  };
+}
+
+describe("formatEventMessage", () => {
+  it("formats a deposit", () => {
+    const result = formatEventMessage(makeItem({ kind: "DEPOSIT", amount: "120.5", asset: "USDC" }));
+    expect(result.title).toBe("Deposit confirmed");
+    expect(result.message).toContain("120.50 USDC");
+    expect(result.message.toLowerCase()).toContain("deposited");
+  });
+
+  it("formats a withdrawal", () => {
+    const result = formatEventMessage(makeItem({ kind: "WITHDRAW", amount: "50", asset: "XLM" }));
+    expect(result.title).toBe("Withdrawal confirmed");
+    expect(result.message).toContain("50.00 XLM");
+    expect(result.message.toLowerCase()).toContain("withdrawn");
+  });
+
+  it("formats a rebalance", () => {
+    const result = formatEventMessage(makeItem({ kind: "REBALANCE", amount: "500", asset: "USDC" }));
+    expect(result.title).toBe("Vault rebalanced");
+    expect(result.message).toContain("500.00 USDC");
+    expect(result.message.toLowerCase()).toContain("rebalanced");
+  });
+
+  it("falls back to the raw amount string if it isn't parseable", () => {
+    const result = formatEventMessage(makeItem({ kind: "DEPOSIT", amount: "not-a-number" }));
+    expect(result.message).toContain("not-a-number");
+  });
+});

--- a/frontend/lib/notifications/formatEventMessage.ts
+++ b/frontend/lib/notifications/formatEventMessage.ts
@@ -1,0 +1,42 @@
+import type { TransactionItem } from "@/types/transactions";
+
+export interface FormattedNotification {
+  title: string;
+  message: string;
+}
+
+function formatAmount(amount: string): string {
+  const num = parseFloat(amount);
+  if (isNaN(num)) return amount;
+  return num.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+/**
+ * Turns a normalized on-chain event into a short title + message pair,
+ * suitable for a toast, the notification center list, or a browser/SW
+ * notification body.
+ */
+export function formatEventMessage(item: TransactionItem): FormattedNotification {
+  const amount = formatAmount(item.amount);
+
+  switch (item.kind) {
+    case "DEPOSIT":
+      return {
+        title: "Deposit confirmed",
+        message: `${amount} ${item.asset} was deposited into your vault position.`,
+      };
+    case "WITHDRAW":
+      return {
+        title: "Withdrawal confirmed",
+        message: `${amount} ${item.asset} was withdrawn from your vault position.`,
+      };
+    case "REBALANCE":
+      return {
+        title: "Vault rebalanced",
+        message: `The vault rebalanced ${amount} ${item.asset} across strategies.`,
+      };
+  }
+}

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }
+
+export function formatRelativeTime(iso: string): string {
+    const date = new Date(iso);
+    const diffMs = Date.now() - date.getTime();
+    const diffHrs = Math.floor(diffMs / 3_600_000);
+
+    if (diffHrs < 1) return "Just now";
+    if (diffHrs < 24) return `${diffHrs}h ago`;
+    const diffDays = Math.floor(diffHrs / 24);
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,29 @@
+// Minimal service worker for opt-in local notifications on vault events
+// (Deposit, Withdraw, Rebalance). There's no push server behind this yet —
+// notifications are shown via `registration.showNotification()`, called by
+// the client when it detects a new event, not via a real Push API payload.
+// The `push` handler below is a no-op placeholder for when that exists.
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", () => {
+  // No backend push service is wired up yet. Once one exists, parse
+  // event.data here and call self.registration.showNotification(...).
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+      const existing = clients.find((c) => "focus" in c);
+      if (existing) return existing.focus();
+      return self.clients.openWindow("/");
+    })
+  );
+});

--- a/frontend/types/transactions.ts
+++ b/frontend/types/transactions.ts
@@ -1,4 +1,4 @@
-export type TransactionKind = "DEPOSIT" | "WITHDRAW";
+export type TransactionKind = "DEPOSIT" | "WITHDRAW" | "REBALANCE";
 
 export interface IndexerEventRaw {
   id: string;


### PR DESCRIPTION
Closes #96

Wires up the notification center: deposit, withdraw, and rebalance events now get turned into plain-language messages, a bell icon in the header shows them with an unread count, and there's a real opt-in flow for browser push through a service worker, replacing the toggle that used to just be local state doing nothing.

Rebalance events didn't exist anywhere in the type system before this, so I added that too, including fixing the transaction history row, which would have mislabeled a rebalance as a withdrawal.

Build passes. Tests pass, added coverage for the message formatting, the event dedup/polling logic, and the push opt-in flow, plus fixed an existing settings test that was asserting the old fake toggle's default.

One thing I'm flagging separately in a comment rather than deciding on my own: there's no backend push infrastructure in this repo, so I want to check with you on how "push" is scoped here before this goes further.