### PR TITLE
[FE-40] Contract Address Configuration Manager #105

### DIFF
--- a/frontend/app/[locale]/settings/page.tsx
+++ b/frontend/app/[locale]/settings/page.tsx
@@ -14,13 +14,30 @@ import {
   User,
   Globe,
   Wallet,
-  Coins
+  Coins,
+  Code,
+  CheckCircle2,
+  XCircle,
+  Copy,
+  Info
 } from 'lucide-react';
+import { useNetwork } from '@/contexts/NetworkContext';
+import { resolveContract, getAllContractNames } from '@/lib/contracts.config';
 
 export default function SettingsPage() {
   const [notifications, setNotifications] = useState(true);
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system');
   const [currency, setCurrency] = useState('USD');
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const { network, networkConfig } = useNetwork();
+  const contractNames = getAllContractNames();
+
+  const handleCopy = (text: string, id: string) => {
+    navigator.clipboard.writeText(text);
+    setCopiedId(id);
+    setTimeout(() => setCopiedId(null), 2000);
+  };
 
   const focusVisibleClass =
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background';
@@ -229,6 +246,65 @@ export default function SettingsPage() {
               >
                 View on Stellar.Expert
               </a>
+            </section>
+
+            {/* Contract & Debug Section */}
+            <section className="bg-card border border-border rounded-2xl overflow-hidden shadow-sm">
+              <div className="p-6 border-b border-border bg-accent/30">
+                <h2 className="font-bold flex items-center gap-2">
+                  <Code className="w-4 h-4 text-primary" />
+                  Contract & Debug
+                </h2>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Active network: <span className="font-bold uppercase">{networkConfig.network}</span>
+                </p>
+              </div>
+              <div className="p-6 space-y-4">
+                {contractNames.map((contractName) => {
+                  const resolved = resolveContract(network, contractName);
+                  return (
+                    <div key={contractName} className="p-4 bg-accent/20 rounded-xl border border-border/50 flex flex-col gap-2">
+                      <div className="flex justify-between items-start">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-semibold capitalize">{contractName} Contract</span>
+                          {resolved.isOverride && (
+                            <span className="text-[10px] bg-primary/20 text-primary px-1.5 py-0.5 rounded font-medium flex items-center gap-1">
+                              <Info className="w-3 h-3" />
+                              ENV OVERRIDE
+                            </span>
+                          )}
+                        </div>
+                        {resolved.isValid ? (
+                          <span className="flex items-center gap-1 text-xs text-emerald-600 bg-emerald-500/10 px-2 py-1 rounded-md font-medium">
+                            <CheckCircle2 className="w-3 h-3" /> Valid
+                          </span>
+                        ) : (
+                          <span className="flex items-center gap-1 text-xs text-rose-600 bg-rose-500/10 px-2 py-1 rounded-md font-medium">
+                            <XCircle className="w-3 h-3" /> Invalid
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 mt-1">
+                        <code className="text-xs bg-background border border-border px-2 py-1 rounded truncate flex-1 opacity-70">
+                          {resolved.address || "Not configured"}
+                        </code>
+                        <button
+                          onClick={() => handleCopy(resolved.address, contractName)}
+                          disabled={!resolved.address}
+                          className="p-1.5 bg-background border border-border rounded hover:bg-accent text-muted-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          title="Copy address"
+                        >
+                          {copiedId === contractName ? (
+                            <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+                          ) : (
+                            <Copy className="w-4 h-4" />
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
             </section>
           </div>
         </div>

--- a/frontend/components/DepositTab.tsx
+++ b/frontend/components/DepositTab.tsx
@@ -15,12 +15,15 @@ import {
     signTransaction,
 } from "@stellar/freighter-api";
 import { SigningOverlay, type SigningStatus } from "./SigningOverlay";
-
-const CONTRACT_ID = "CCWHG2Q4VFY6XCQB4S4A4R6XYLFXSFTNQQYJAY4GZRXF2WYYX3F5YRP";
-const RPC_URL = "https://soroban-testnet.stellar.org";
-const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+import { useContractAddress } from "@/hooks/useContractAddress";
+import { useNetwork } from "@/contexts/NetworkContext";
 
 export function DepositTab() {
+    const contractId = useContractAddress("vault");
+    const { networkConfig } = useNetwork();
+    const rpcUrl = networkConfig.rpcUrl;
+    const networkPassphrase = networkConfig.networkPassphrase;
+
     const [address, setAddress] = useState<string>("");
     const [amount, setAmount] = useState<string>("");
     const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -46,7 +49,7 @@ export function DepositTab() {
         }
         async function fetchFee() {
             try {
-                const server = new SorobanRpc.Server(RPC_URL);
+                const server = new SorobanRpc.Server(rpcUrl);
                 const feeStats = await server.getFeeStats();
                 setEstimatedFee(`${feeStats.sorobanInclusionFee.min} stroops`);
             } catch {
@@ -98,16 +101,16 @@ export function DepositTab() {
         setOverlayError(null);
 
         try {
-            const server = new SorobanRpc.Server(RPC_URL);
+            const server = new SorobanRpc.Server(rpcUrl);
 
             const account = await server.getAccount(address);
 
             setOverlayStatus("building");
-            const contract = new Contract(CONTRACT_ID);
+            const contract = new Contract(contractId);
 
             const tx = new TransactionBuilder(account, {
                 fee: "1000",
-                networkPassphrase: NETWORK_PASSPHRASE,
+                networkPassphrase: networkPassphrase,
             })
                 .addOperation(
                     contract.call(
@@ -135,11 +138,11 @@ export function DepositTab() {
 
             setOverlayStatus("signing");
             const signedXdr = await signTransaction(preparedTxBuilder.build().toXDR(), {
-                networkPassphrase: NETWORK_PASSPHRASE,
+                networkPassphrase: networkPassphrase,
             });
 
             setOverlayStatus("submitting");
-            const txToSubmit = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
+            const txToSubmit = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
             const result = await server.sendTransaction(txToSubmit);
 
             if (result.status !== "PENDING") {

--- a/frontend/components/StrategyAllocationPie.tsx
+++ b/frontend/components/StrategyAllocationPie.tsx
@@ -10,6 +10,8 @@ import {
     Legend,
 } from "recharts";
 import * as StellarSdk from "@stellar/stellar-sdk";
+import { useContractAddress } from "@/hooks/useContractAddress";
+import { useNetwork } from "@/contexts/NetworkContext";
 
 interface AllocationData {
     name: string;
@@ -24,29 +26,21 @@ const MOCK_ALLOCATION: AllocationData[] = [
 ];
 
 export function StrategyAllocationPie() {
+    const contractId = useContractAddress("vault");
+    const { networkConfig } = useNetwork();
+    
     const [data, setData] = useState<AllocationData[]>(MOCK_ALLOCATION);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         async function fetchAllocation() {
-            const contractId = process.env.NEXT_PUBLIC_CONTRACT_ID;
-
-            if (!contractId) {
-                // Fallback to mock data if no contract is configured
-                setData(MOCK_ALLOCATION);
-                setIsLoading(false);
-                return;
-            }
-
             try {
-                const server = new StellarSdk.SorobanRpc.Server(
-                    process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org"
-                );
+                const server = new StellarSdk.SorobanRpc.Server(networkConfig.rpcUrl);
 
                 // Example invocation to a hypothetical get_allocations method
                 const txBuilder = new StellarSdk.TransactionBuilder(
                     new StellarSdk.Account("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF", "1"),
-                    { fee: "100", networkPassphrase: StellarSdk.Networks.TESTNET }
+                    { fee: "100", networkPassphrase: networkConfig.networkPassphrase }
                 );
 
                 // This simulates a contract simulation to fetch data (read-only)
@@ -65,7 +59,7 @@ export function StrategyAllocationPie() {
         }
 
         fetchAllocation();
-    }, []);
+    }, [contractId, networkConfig]);
 
     if (isLoading) {
         return (

--- a/frontend/components/VaultOverviewCard.tsx
+++ b/frontend/components/VaultOverviewCard.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
-import { getProvider, activeNetwork } from "../lib/network";
+import { getProvider } from "../lib/network";
 import { Contract, TransactionBuilder, Account, xdr, SorobanRpc } from "@stellar/stellar-sdk";
 import { isConnected, requestAccess } from "@stellar/freighter-api";
 import { useCurrency } from "@/contexts/CurrencyContext";
-
-// The contract ID should ideally come from an .env file or config
-const VAULT_CONTRACT_ID = "CCWHG2Q4VFY6XCQB4S4A4R6XYLFXSFTNQQYJAY4GZRXF2WYYX3F5YRP";
+import { useContractAddress } from "@/hooks/useContractAddress";
+import { useNetwork } from "@/contexts/NetworkContext";
 
 export function VaultOverviewCard() {
+    const contractId = useContractAddress("vault");
+    const { network, networkConfig } = useNetwork();
     const { formatAmount } = useCurrency();
     const [totalAssets, setTotalAssets] = useState<number | null>(null);
     const [totalShares, setTotalShares] = useState<number | null>(null);
@@ -26,7 +27,7 @@ export function VaultOverviewCard() {
     useEffect(() => {
         let isMounted = true;
         let pollInterval: NodeJS.Timeout;
-        const server = getProvider("testnet");
+        const server = getProvider(network);
 
         async function init() {
             setIsLoading(true);
@@ -56,7 +57,7 @@ export function VaultOverviewCard() {
                             filters: [
                                 {
                                     type: "contract",
-                                    contractIds: [VAULT_CONTRACT_ID]
+                                    contractIds: [contractId]
                                 }
                             ],
                             limit: 100
@@ -88,7 +89,7 @@ export function VaultOverviewCard() {
             isMounted = false;
             if (pollInterval) clearInterval(pollInterval);
         };
-    }, []);
+    }, [network, contractId]);
 
     const fetchVaultData = async (userAddr: string) => {
         try {
@@ -122,7 +123,7 @@ export function VaultOverviewCard() {
                     <span>🏦</span> Vault Overview
                 </h2>
                 <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded-full uppercase font-medium">
-                    {activeNetwork.network}
+                    {networkConfig.network}
                 </span>
                 <span className="flex h-3 w-3 relative ml-2">
                     <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>

--- a/frontend/components/WithdrawTab.tsx
+++ b/frontend/components/WithdrawTab.tsx
@@ -15,12 +15,15 @@ import {
     signTransaction,
 } from "@stellar/freighter-api";
 import { SigningOverlay, type SigningStatus } from "./SigningOverlay";
-
-const CONTRACT_ID = "CCWHG2Q4VFY6XCQB4S4A4R6XYLFXSFTNQQYJAY4GZRXF2WYYX3F5YRP";
-const RPC_URL = "https://soroban-testnet.stellar.org";
-const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+import { useContractAddress } from "@/hooks/useContractAddress";
+import { useNetwork } from "@/contexts/NetworkContext";
 
 export function WithdrawTab() {
+    const contractId = useContractAddress("vault");
+    const { networkConfig } = useNetwork();
+    const rpcUrl = networkConfig.rpcUrl;
+    const networkPassphrase = networkConfig.networkPassphrase;
+
     const [address, setAddress] = useState<string>("");
     const [amount, setAmount] = useState<string>("");
     const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -46,7 +49,7 @@ export function WithdrawTab() {
         }
         async function fetchFee() {
             try {
-                const server = new SorobanRpc.Server(RPC_URL);
+                const server = new SorobanRpc.Server(rpcUrl);
                 const feeStats = await server.getFeeStats();
                 setEstimatedFee(`${feeStats.sorobanInclusionFee.min} stroops`);
             } catch {
@@ -98,16 +101,16 @@ export function WithdrawTab() {
         setOverlayError(null);
 
         try {
-            const server = new SorobanRpc.Server(RPC_URL);
+            const server = new SorobanRpc.Server(rpcUrl);
 
             const account = await server.getAccount(address);
 
             setOverlayStatus("building");
-            const contract = new Contract(CONTRACT_ID);
+            const contract = new Contract(contractId);
 
             const tx = new TransactionBuilder(account, {
                 fee: "1000",
-                networkPassphrase: NETWORK_PASSPHRASE,
+                networkPassphrase: networkPassphrase,
             })
                 .addOperation(
                     contract.call(
@@ -135,11 +138,11 @@ export function WithdrawTab() {
 
             setOverlayStatus("signing");
             const signedXdr = await signTransaction(preparedTxBuilder.build().toXDR(), {
-                networkPassphrase: NETWORK_PASSPHRASE,
+                networkPassphrase: networkPassphrase,
             });
 
             setOverlayStatus("submitting");
-            const txToSubmit = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
+            const txToSubmit = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
             const result = await server.sendTransaction(txToSubmit);
 
             if (result.status !== "PENDING") {

--- a/frontend/hooks/useContractAddress.ts
+++ b/frontend/hooks/useContractAddress.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useMemo } from "react";
+import { useNetwork } from "@/contexts/NetworkContext";
+import {
+  getContractAddress,
+  type ContractName,
+} from "@/lib/contracts.config";
+
+/**
+ * React hook that returns the correct Stellar contract address for the
+ * currently selected network.
+ *
+ * Resolution order:
+ * 1. Environment variable override (e.g. `NEXT_PUBLIC_VAULT_CONTRACT_ID`)
+ * 2. Static `CONTRACT_ADDRESSES` config for the active network
+ *
+ * @param contractName — which contract to resolve (e.g. `"vault"`)
+ * @returns The 56-char Stellar contract ID string
+ * @throws If the address is missing or has an invalid Stellar format
+ *
+ * @example
+ * ```tsx
+ * const vaultContractId = useContractAddress("vault");
+ * ```
+ */
+export function useContractAddress(contractName: ContractName): string {
+  const { network } = useNetwork();
+
+  return useMemo(
+    () => getContractAddress(network, contractName),
+    [network, contractName],
+  );
+}

--- a/frontend/lib/contracts.config.ts
+++ b/frontend/lib/contracts.config.ts
@@ -1,0 +1,162 @@
+import type { NetworkName } from "./network";
+
+// ============================================================================
+// Contract Names
+// ============================================================================
+
+/**
+ * Known contract identifiers managed by the application.
+ * Add new entries here as more contracts are deployed.
+ */
+export type ContractName = "vault" | "token" | "governance";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** A mapping from every ContractName to its Stellar contract address. */
+export type ContractAddresses = Record<ContractName, string>;
+
+/** Metadata about a resolved contract address. */
+export interface ResolvedContract {
+  /** The contract address (C…) */
+  address: string;
+  /** Whether the address came from an environment variable override */
+  isOverride: boolean;
+  /** Whether the address passes Stellar format validation */
+  isValid: boolean;
+}
+
+// ============================================================================
+// Static address map — one entry per network
+// ============================================================================
+
+/**
+ * Default contract addresses per Stellar network.
+ *
+ * These are the canonical addresses committed to the repository.
+ * For local development overrides, set the corresponding
+ * `NEXT_PUBLIC_*_CONTRACT_ID` environment variable instead of
+ * editing this map.
+ */
+export const CONTRACT_ADDRESSES: Record<NetworkName, ContractAddresses> = {
+  testnet: {
+    vault: "CCWHG2Q4VFY6XCQB4S4A4R6XYLFXSFTNQQYJAY4GZRXF2WYYX3F5YRP",
+    token: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+    governance: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+  },
+  mainnet: {
+    vault: "",
+    token: "",
+    governance: "",
+  },
+  futurenet: {
+    vault: "",
+    token: "",
+    governance: "",
+  },
+};
+
+// ============================================================================
+// Environment variable override mapping
+// ============================================================================
+
+/**
+ * Maps each ContractName to the `NEXT_PUBLIC_*` env var that can override it.
+ */
+const ENV_VAR_MAP: Record<ContractName, string> = {
+  vault: "NEXT_PUBLIC_VAULT_CONTRACT_ID",
+  token: "NEXT_PUBLIC_TOKEN_CONTRACT_ID",
+  governance: "NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID",
+};
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/** Valid base-32 alphabet used by Stellar strkeys (RFC 4648). */
+const STELLAR_BASE32_REGEX = /^[A-Z2-7]+$/;
+
+/**
+ * Returns `true` if `id` looks like a valid Stellar contract address.
+ *
+ * Checks:
+ * 1. Non-empty string
+ * 2. Exactly 56 characters long
+ * 3. Starts with `C` (Stellar contract strkey prefix)
+ * 4. Contains only valid base-32 characters [A-Z2-7]
+ */
+export function isValidStellarContractId(id: string): boolean {
+  if (!id || id.length !== 56) return false;
+  if (!id.startsWith("C")) return false;
+  return STELLAR_BASE32_REGEX.test(id);
+}
+
+// ============================================================================
+// Resolver
+// ============================================================================
+
+/**
+ * Resolve the contract address for a given network and contract name.
+ *
+ * Resolution order:
+ * 1. Environment variable override (e.g. `NEXT_PUBLIC_VAULT_CONTRACT_ID`)
+ * 2. Static `CONTRACT_ADDRESSES` map
+ *
+ * @throws {Error} If the resolved address is empty or has an invalid format.
+ */
+export function getContractAddress(
+  network: NetworkName,
+  contractName: ContractName,
+): string {
+  const envVar = ENV_VAR_MAP[contractName];
+  const envValue =
+    typeof process !== "undefined" ? process.env[envVar] : undefined;
+
+  const address = envValue || CONTRACT_ADDRESSES[network]?.[contractName] || "";
+
+  if (!address) {
+    throw new Error(
+      `No contract address configured for "${contractName}" on "${network}". ` +
+        `Set the ${envVar} environment variable or update CONTRACT_ADDRESSES in contracts.config.ts.`,
+    );
+  }
+
+  if (!isValidStellarContractId(address)) {
+    throw new Error(
+      `Invalid Stellar contract address for "${contractName}" on "${network}": "${address}". ` +
+        `Expected a 56-character base-32 string starting with "C".`,
+    );
+  }
+
+  return address;
+}
+
+/**
+ * Resolve a contract address with full metadata (for debug UIs).
+ *
+ * Unlike `getContractAddress`, this function never throws — it returns
+ * validation / override information alongside the address so the
+ * Settings/Debug panel can display it.
+ */
+export function resolveContract(
+  network: NetworkName,
+  contractName: ContractName,
+): ResolvedContract {
+  const envVar = ENV_VAR_MAP[contractName];
+  const envValue =
+    typeof process !== "undefined" ? process.env[envVar] : undefined;
+
+  const isOverride = !!envValue;
+  const address = envValue || CONTRACT_ADDRESSES[network]?.[contractName] || "";
+  const isValid = isValidStellarContractId(address);
+
+  return { address, isOverride, isValid };
+}
+
+/**
+ * Returns all contract names defined in the system.
+ */
+export function getAllContractNames(): ContractName[] {
+  return Object.keys(ENV_VAR_MAP) as ContractName[];
+}


### PR DESCRIPTION
Closes #105

@bbkenny, review is ready!

### Description
Implemented a centralized configuration for contract addresses per network. Replaced all hardcoded instances of the contract address with the newly added `useContractAddress` hook that auto-selects the correct contract ID based on the active NetworkContext.
Also added a **Contract & Debug** section to the Settings page as requested.
Verified that the `npm run build` passes successfully in the frontend directory.