### PR TITLE
Issue 109: FE-44b security headers

### DIFF
--- a/frontend/e2e/security.spec.ts
+++ b/frontend/e2e/security.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('security headers', () => {
+  test('sends anti-framing and content-type hardening headers', async ({ page }) => {
+    const response = await page.goto('/');
+
+    expect(response?.headers()['x-frame-options']).toBe('DENY');
+    expect(response?.headers()['x-content-type-options']).toBe('nosniff');
+    expect(response?.headers()['strict-transport-security']).toContain('max-age=63072000');
+  });
+
+  test('does not load third-party scripts without consent', async ({ page }) => {
+    await page.goto('/');
+
+    const externalScripts = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('script[src]'))
+        .map((script) => new URL((script as HTMLScriptElement).src, window.location.href))
+        .filter((src) => src.origin !== window.location.origin)
+        .map((src) => src.href),
+    );
+
+    expect(externalScripts).toEqual([]);
+  });
+});

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -14,6 +14,10 @@ const nextConfig = {
             value: 'nosniff',
           },
           {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
             key: 'Referrer-Policy',
             value: 'strict-origin-when-cross-origin',
           },


### PR DESCRIPTION
## Summary
Fixes issue 109: FE-44b Security Headers — Transport & Frame Protection.

## What changed
- Added `X-Frame-Options: DENY` to the Next.js header configuration.
- Added an end-to-end regression test that checks the security headers and ensures no third-party scripts load without consent.

## Validation
- `npm run build` in `frontend`
- `npx playwright test e2e/security.spec.ts`

## Notes
Fixes #109
@bbkenny
