### PR TITLE
[FE-31] Asset Breakdown Tooltips

### DIFF
--- a/frontend/components/StrategyAllocationPie.tsx
+++ b/frontend/components/StrategyAllocationPie.tsx
@@ -17,12 +17,15 @@ interface AllocationData {
     name: string;
     value: number;
     color: string;
+    /** Per-asset risk score, 1 (lowest) to 10 (highest). */
+    riskScore: number;
+    riskLabel: string;
 }
 
 const MOCK_ALLOCATION: AllocationData[] = [
-    { name: "USDC Reserves", value: 40, color: "hsl(var(--primary))" },
-    { name: "Stellar LP", value: 35, color: "hsl(var(--primary) / 0.7)" },
-    { name: "Synthetic Hedges", value: 25, color: "hsl(var(--primary) / 0.4)" },
+    { name: "USDC Reserves", value: 40, color: "hsl(var(--primary))", riskScore: 1, riskLabel: "Low Risk" },
+    { name: "Stellar LP", value: 35, color: "hsl(var(--primary) / 0.7)", riskScore: 4, riskLabel: "Moderate Risk" },
+    { name: "Synthetic Hedges", value: 25, color: "hsl(var(--primary) / 0.4)", riskScore: 7, riskLabel: "Elevated Risk" },
 ];
 
 export function StrategyAllocationPie() {
@@ -71,9 +74,14 @@ export function StrategyAllocationPie() {
 
     const CustomTooltip = ({ active, payload }: any) => {
         if (active && payload && payload.length) {
+            const asset: AllocationData = payload[0].payload;
             return (
-                <div className="bg-background border rounded-lg p-3 shadow-sm">
-                    <p className="font-medium text-sm">{`${payload[0].name}: ${payload[0].value}%`}</p>
+                <div className="bg-background border rounded-lg p-3 shadow-sm space-y-1">
+                    <p className="font-medium text-sm">{`${asset.name}: ${asset.value}%`}</p>
+                    <p className="text-xs text-muted-foreground">
+                        Risk Score: <span className="font-medium text-foreground">{asset.riskScore}/10</span>
+                        {" "}({asset.riskLabel})
+                    </p>
                 </div>
             );
         }


### PR DESCRIPTION
## Summary

- Added a per-asset risk score (1-10 scale + qualitative label: Low/Moderate/Elevated Risk) to each slice of the `StrategyAllocationPie` chart, surfaced in the existing hover tooltip alongside name/percentage.

## Acceptance criteria

- [x] Add hover tooltips to the Allocation Pie chart — the chart already had a `CustomTooltip` wired to recharts' `Tooltip`; kept and extended it.
- [x] Show risk score per individual asset — each asset now carries a `riskScore`/`riskLabel`, rendered in the tooltip on hover.

## Testing

`cd frontend && npm install --legacy-peer-deps && npm run build` — compiles and builds cleanly.

@bbkenny, PR is ready for review!

Closes #92