### PR TITLE
[FE-32] Production Build & SEO

### DIFF
--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { getMessages } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { routing } from '../../i18n/routing';
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { siteUrl, siteName, siteDescription } from "@/lib/siteConfig";
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -13,8 +14,36 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  title: "X-Aegis",
-  description: "Stablecoin Volatility Shield for Weak Currencies",
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: siteName,
+    template: `%s | ${siteName}`,
+  },
+  description: siteDescription,
+  keywords: [
+    "Stellar",
+    "Soroban",
+    "stablecoin",
+    "hedging",
+    "DeFi",
+    "volatility protection",
+  ],
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    type: "website",
+    siteName,
+    title: siteName,
+    description: siteDescription,
+    url: siteUrl,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteName,
+    description: siteDescription,
+  },
 };
 
 export default async function RootLayout({

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/lib/siteConfig";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/lib/siteConfig";
+import { routing } from "@/i18n/routing";
+
+const STATIC_ROUTES = ["", "/bridge", "/settings"];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  return routing.locales.flatMap((locale) =>
+    STATIC_ROUTES.map((route) => ({
+      url: `${siteUrl}/${locale}${route}`,
+      lastModified: now,
+      changeFrequency: "daily" as const,
+      priority: route === "" ? 1 : 0.8,
+    })),
+  );
+}

--- a/frontend/lib/siteConfig.ts
+++ b/frontend/lib/siteConfig.ts
@@ -1,0 +1,11 @@
+/**
+ * Canonical production URL, used for metadataBase, sitemap.xml, and robots.txt.
+ * Falls back to the Vercel-injected deployment URL, then localhost for local dev.
+ * Set NEXT_PUBLIC_SITE_URL in production to the real custom domain.
+ */
+export const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
+
+export const siteName = "X-Aegis";
+export const siteDescription = "Stablecoin Volatility Shield for Weak Currencies";

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -4,6 +4,9 @@ const withNextIntl = createNextIntlPlugin();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: true,
+  poweredByHeader: false,
+  compress: true,
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary

- **`next.config.mjs` for production**: `reactStrictMode: true`, `poweredByHeader: false` (drops the `X-Powered-By` header), `compress: true`, alongside the existing security headers.
- **Meta tags**: expanded root metadata in `app/[locale]/layout.tsx` — `metadataBase`, a title template (`%s | X-Aegis`), `keywords`, explicit `robots: { index: true, follow: true }`, OpenGraph, and a Twitter card. Driven by a new `lib/siteConfig.ts` that resolves the canonical site URL from `NEXT_PUBLIC_SITE_URL`, falling back to Vercel's injected deployment URL, then `localhost` for local dev.
- **Sitemap**: `app/sitemap.ts` using Next's native `MetadataRoute.Sitemap` convention — generates entries for every locale (`en`, `es`) × static route (`/`, `/bridge`, `/settings`).
- **Robots**: `app/robots.ts` — allows all crawlers, references the generated sitemap.

## Acceptance criteria

- [x] Configure `next.config.js` for production
- [x] Implement Meta tags and Sitemap

## Verification

`cd frontend && npm install --legacy-peer-deps && npm run build` — build output confirms both `/robots.txt` and `/sitemap.xml` are generated as static routes:

```
├ ○ /robots.txt
└ ○ /sitemap.xml
```

Set `NEXT_PUBLIC_SITE_URL` in the production environment to the real custom domain once one is assigned.

@bbkenny, PR is ready for review!

Closes #93