### PR TITLE
[FE-32] Production Build & SEO

### DIFF
--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -12,9 +12,33 @@ export const viewport: Viewport = {
   initialScale: 1,
 };
 
+// Placeholder production domain -- override with the real deployment URL
+// via NEXT_PUBLIC_SITE_URL once one is assigned. Consumed here and by
+// app/sitemap.ts / app/robots.ts so there is a single source of truth.
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://xaegis.app";
+const SITE_TITLE = "X-Aegis — Stablecoin Volatility Shield";
+const SITE_DESCRIPTION = "Stablecoin Volatility Shield for Weak Currencies";
+
 export const metadata: Metadata = {
-  title: "X-Aegis",
-  description: "Stablecoin Volatility Shield for Weak Currencies",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: SITE_TITLE,
+    template: "%s | X-Aegis",
+  },
+  description: SITE_DESCRIPTION,
+  keywords: ["X-Aegis", "stablecoin", "volatility hedge", "Stellar", "Soroban", "DeFi", "vault"],
+  robots: { index: true, follow: true },
+  openGraph: {
+    type: "website",
+    siteName: "X-Aegis",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
 };
 
 export default async function RootLayout({

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+// Placeholder production domain -- see app/[locale]/layout.tsx for the same
+// fallback and the note on overriding it via NEXT_PUBLIC_SITE_URL.
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://xaegis.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+import { routing } from "@/i18n/routing";
+
+// Placeholder production domain -- see app/[locale]/layout.tsx for the same
+// fallback and the note on overriding it via NEXT_PUBLIC_SITE_URL.
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://xaegis.app";
+
+// Static routes only -- /vaults/[id] is omitted since vault ids are
+// on-chain data, not known at build time.
+const STATIC_ROUTES = ["", "/bridge", "/settings"];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return routing.locales.flatMap((locale) =>
+    STATIC_ROUTES.map((route) => ({
+      url: `${SITE_URL}/${locale}${route}`,
+      lastModified,
+      changeFrequency: "weekly" as const,
+      priority: route === "" ? 1 : 0.7,
+    })),
+  );
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -4,6 +4,11 @@ const withNextIntl = createNextIntlPlugin();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Production hardening: catch unsafe lifecycle/effects in dev, and stop
+  // advertising the framework (X-Powered-By) to reduce fingerprinting --
+  // consistent with the security headers already set below.
+  reactStrictMode: true,
+  poweredByHeader: false,
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- `next.config.mjs`: `reactStrictMode` + `poweredByHeader: false` for production (the latter stops advertising the framework, consistent with the existing `headers()` security block).
- `app/[locale]/layout.tsx`: expanded `metadata` — `metadataBase`, a title template, keywords, explicit `robots` directives, OpenGraph and Twitter card tags. `SITE_URL` is a single-source-of-truth placeholder domain, overridable via `NEXT_PUBLIC_SITE_URL` once a real one is assigned (also consumed by `sitemap.ts`/`robots.ts`).
- `app/sitemap.ts`: static routes (`/`, `/bridge`, `/settings`) for every locale in `i18n/routing.ts`. `/vaults/[id]` is intentionally omitted — vault ids are on-chain data, not known at build time.
- `app/robots.ts`: allow-all rule pointing at the generated sitemap.

Closes #93.

## Acceptance criteria
- [x] Configure `next.config.js` for production.
- [x] Implement Meta tags and Sitemap.

## Verification
`cd frontend && npm install --legacy-peer-deps && npm run build` succeeds locally, with `/robots.txt` and `/sitemap.xml` appearing as statically generated routes in the build output.

@bbkenny, PR is ready for review!