### PR TITLE
[FE-47a] Notification Center — Core Infrastructure

### DIFF
--- a/frontend/app/[locale]/providers.tsx
+++ b/frontend/app/[locale]/providers.tsx
@@ -8,6 +8,7 @@ import { SessionProvider } from "@/contexts/SessionContext";
 import { CurrencyProvider } from "@/contexts/CurrencyContext";
 import { NetworkProvider } from "@/contexts/NetworkContext";
 import { VaultProvider } from "@/contexts/VaultContext";
+import { NotificationProvider } from "@/contexts/NotificationContext";
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
@@ -16,7 +17,9 @@ export function Providers({ children }: { children: ReactNode }) {
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <CurrencyProvider>
             <VaultProvider>
-              <SessionProvider>{children}</SessionProvider>
+              <SessionProvider>
+                <NotificationProvider>{children}</NotificationProvider>
+              </SessionProvider>
             </VaultProvider>
           </CurrencyProvider>
           <Toaster richColors closeButton position="bottom-right" />

--- a/frontend/components/NotificationCenter.tsx
+++ b/frontend/components/NotificationCenter.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback } from "react";
-import { Bell, ArrowDownLeft, ArrowUpRight, RefreshCw } from "lucide-react";
+import { useCallback, useEffect } from "react";
+import { Bell, ArrowDownLeft, ArrowUpRight, RefreshCw, X, Info, AlertTriangle, Settings } from "lucide-react";
 import { useFreighter } from "@/contexts/FreighterContext";
 import { useOnChainNotifications, type NotificationEntry } from "@/hooks/useOnChainNotifications";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
+import { useNotifications, type AppNotification, type NotificationCategory } from "@/contexts/NotificationContext";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { formatRelativeTime } from "@/lib/utils";
 import type { TransactionKind } from "@/types/transactions";
@@ -15,11 +16,43 @@ const KIND_ICON: Record<TransactionKind, typeof Bell> = {
   REBALANCE: RefreshCw,
 };
 
-function NotificationRow({ entry }: { entry: NotificationEntry }) {
-  const Icon = KIND_ICON[entry.kind];
+const CATEGORY_ICON: Record<NotificationCategory, typeof Bell> = {
+  transaction: RefreshCw,
+  risk: AlertTriangle,
+  system: Settings,
+  info: Info,
+};
+
+const CATEGORY_LABEL: Record<NotificationCategory, string> = {
+  transaction: "Transactions",
+  risk: "Risk Alerts",
+  system: "System",
+  info: "Info",
+};
+
+function iconForNotification(entry: AppNotification) {
+  return CATEGORY_ICON[entry.category] ?? Bell;
+}
+
+function NotificationRow({
+  entry,
+  onMarkRead,
+  onDismiss,
+}: {
+  entry: AppNotification;
+  onMarkRead: (id: string) => void;
+  onDismiss: (id: string) => void;
+}) {
+  const Icon = iconForNotification(entry);
   return (
     <div
-      className={`flex items-start gap-2.5 px-3 py-2.5 border-b border-border last:border-0 ${
+      role="button"
+      tabIndex={0}
+      onClick={() => onMarkRead(entry.id)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onMarkRead(entry.id);
+      }}
+      className={`group flex items-start gap-2.5 px-3 py-2.5 border-b border-border last:border-0 cursor-pointer ${
         entry.read ? "" : "bg-primary/5"
       }`}
     >
@@ -36,6 +69,17 @@ function NotificationRow({ entry }: { entry: NotificationEntry }) {
       {!entry.read && (
         <span className="w-1.5 h-1.5 rounded-full bg-primary shrink-0 mt-1.5" aria-hidden="true" />
       )}
+      <button
+        type="button"
+        aria-label={`Dismiss notification: ${entry.title}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onDismiss(entry.id);
+        }}
+        className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-0.5 rounded hover:bg-muted shrink-0 transition-opacity"
+      >
+        <X className="w-3 h-3 text-muted-foreground" />
+      </button>
     </div>
   );
 }
@@ -43,6 +87,8 @@ function NotificationRow({ entry }: { entry: NotificationEntry }) {
 export function NotificationCenter() {
   const { address } = useFreighter();
   const { showNotification } = usePushNotifications();
+  const { notifications, unreadCount, addNotification, markRead, markAllRead, dismiss } =
+    useNotifications();
 
   const onNewEntries = useCallback(
     (entries: NotificationEntry[]) => {
@@ -55,19 +101,33 @@ export function NotificationCenter() {
     [showNotification]
   );
 
-  const { notifications, unreadCount, markAllRead } = useOnChainNotifications({
+  const { notifications: onChainNotifications } = useOnChainNotifications({
     account: address,
     onNewEntries,
   });
+
+  // Feed on-chain events into the shared, categorized notification store.
+  // addNotification is idempotent by id, so re-running this on every poll
+  // tick is cheap and safe.
+  useEffect(() => {
+    onChainNotifications.forEach((entry) => {
+      addNotification({
+        id: entry.id,
+        category: "transaction",
+        title: entry.title,
+        message: entry.message,
+        timestampISO: entry.timestampISO,
+      });
+    });
+  }, [onChainNotifications, addNotification]);
+
+  const categories = Array.from(new Set(notifications.map((n) => n.category)));
 
   return (
     <Popover>
       <PopoverTrigger
         className="relative p-2 hover:bg-muted rounded-lg transition-colors"
         aria-label={unreadCount > 0 ? `Notifications, ${unreadCount} unread` : "Notifications"}
-        onClick={() => {
-          if (unreadCount > 0) markAllRead();
-        }}
       >
         <Bell className="w-5 h-5" />
         {unreadCount > 0 && (
@@ -81,8 +141,17 @@ export function NotificationCenter() {
       </PopoverTrigger>
 
       <PopoverContent className="max-h-[400px] overflow-hidden flex flex-col">
-        <div className="px-3 py-2.5 border-b border-border">
+        <div className="px-3 py-2.5 border-b border-border flex items-center justify-between">
           <p className="text-sm font-bold">Notifications</p>
+          {unreadCount > 0 && (
+            <button
+              type="button"
+              onClick={markAllRead}
+              className="text-[11px] font-medium text-primary hover:underline"
+            >
+              Mark all read
+            </button>
+          )}
         </div>
 
         <div className="overflow-y-auto flex-1">
@@ -91,7 +160,23 @@ export function NotificationCenter() {
               No notifications yet
             </p>
           ) : (
-            notifications.map((entry) => <NotificationRow key={entry.id} entry={entry} />)
+            categories.map((category) => (
+              <div key={category}>
+                <p className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+                  {CATEGORY_LABEL[category]}
+                </p>
+                {notifications
+                  .filter((n) => n.category === category)
+                  .map((entry) => (
+                    <NotificationRow
+                      key={entry.id}
+                      entry={entry}
+                      onMarkRead={markRead}
+                      onDismiss={dismiss}
+                    />
+                  ))}
+              </div>
+            ))
           )}
         </div>
       </PopoverContent>

--- a/frontend/contexts/NotificationContext.test.tsx
+++ b/frontend/contexts/NotificationContext.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { NotificationProvider, useNotifications } from "./NotificationContext";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+function TestConsumer() {
+  const { notifications, unreadCount, addNotification, markRead, markAllRead, dismiss } =
+    useNotifications();
+
+  return (
+    <div>
+      <p data-testid="unread-count">{unreadCount}</p>
+      <p data-testid="total-count">{notifications.length}</p>
+      <button
+        onClick={() =>
+          addNotification({ id: "1", category: "risk", title: "Risk alert", message: "High volatility" })
+        }
+      >
+        add
+      </button>
+      <button onClick={() => markRead("1")}>markRead</button>
+      <button onClick={markAllRead}>markAllRead</button>
+      <button onClick={() => dismiss("1")}>dismiss</button>
+      {notifications.map((n) => (
+        <p key={n.id} data-testid={`entry-${n.id}`}>
+          {n.title}:{n.read ? "read" : "unread"}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <NotificationProvider>
+      <TestConsumer />
+    </NotificationProvider>,
+  );
+}
+
+describe("NotificationContext", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("throws when useNotifications is used outside a provider", () => {
+    const OutsideConsumer = () => {
+      useNotifications();
+      return null;
+    };
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<OutsideConsumer />)).toThrow(
+      "useNotifications must be used within a NotificationProvider",
+    );
+    spy.mockRestore();
+  });
+
+  it("starts empty and adds a notification as unread", () => {
+    renderWithProvider();
+    expect(screen.getByTestId("total-count")).toHaveTextContent("0");
+
+    act(() => screen.getByText("add").click());
+
+    expect(screen.getByTestId("total-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("entry-1")).toHaveTextContent("Risk alert:unread");
+  });
+
+  it("is idempotent when adding the same id twice", () => {
+    renderWithProvider();
+    act(() => screen.getByText("add").click());
+    act(() => screen.getByText("add").click());
+    expect(screen.getByTestId("total-count")).toHaveTextContent("1");
+  });
+
+  it("marks a single notification read", () => {
+    renderWithProvider();
+    act(() => screen.getByText("add").click());
+    act(() => screen.getByText("markRead").click());
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("entry-1")).toHaveTextContent("Risk alert:read");
+  });
+
+  it("marks all notifications read", () => {
+    renderWithProvider();
+    act(() => screen.getByText("add").click());
+    act(() => screen.getByText("markAllRead").click());
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("0");
+  });
+
+  it("dismisses a notification, removing it entirely", () => {
+    renderWithProvider();
+    act(() => screen.getByText("add").click());
+    act(() => screen.getByText("dismiss").click());
+    expect(screen.getByTestId("total-count")).toHaveTextContent("0");
+  });
+
+  it("persists notifications to localStorage across mounts", () => {
+    const { unmount } = renderWithProvider();
+    act(() => screen.getByText("add").click());
+    unmount();
+
+    renderWithProvider();
+    expect(screen.getByTestId("total-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("entry-1")).toHaveTextContent("Risk alert:unread");
+  });
+});

--- a/frontend/contexts/NotificationContext.tsx
+++ b/frontend/contexts/NotificationContext.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  ReactNode,
+} from "react";
+
+const STORAGE_KEY = "aegis_notifications";
+const MAX_STORED = 100;
+
+export type NotificationCategory = "transaction" | "risk" | "system" | "info";
+
+export interface AppNotification {
+  id: string;
+  category: NotificationCategory;
+  title: string;
+  message: string;
+  timestampISO: string;
+  read: boolean;
+}
+
+export type NewNotificationInput = Omit<AppNotification, "timestampISO" | "read"> & {
+  timestampISO?: string;
+};
+
+interface NotificationContextType {
+  notifications: AppNotification[];
+  unreadCount: number;
+  /** Adds a notification. Idempotent by `id` — re-adding an existing id is a no-op. */
+  addNotification: (input: NewNotificationInput) => void;
+  markRead: (id: string) => void;
+  markAllRead: () => void;
+  dismiss: (id: string) => void;
+  clear: () => void;
+}
+
+const NotificationContext = createContext<NotificationContextType | null>(null);
+
+function readStored(): AppNotification[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as AppNotification[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStored(list: AppNotification[]) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // storage full or unavailable — notifications still work for this session
+  }
+}
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const [notifications, setNotifications] = useState<AppNotification[]>(() => readStored());
+
+  useEffect(() => {
+    writeStored(notifications);
+  }, [notifications]);
+
+  const addNotification = useCallback((input: NewNotificationInput) => {
+    setNotifications((prev) => {
+      if (prev.some((n) => n.id === input.id)) return prev;
+      const next: AppNotification = {
+        id: input.id,
+        category: input.category,
+        title: input.title,
+        message: input.message,
+        timestampISO: input.timestampISO ?? new Date().toISOString(),
+        read: false,
+      };
+      return [next, ...prev].slice(0, MAX_STORED);
+    });
+  }, []);
+
+  const markRead = useCallback((id: string) => {
+    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+  }, []);
+
+  const markAllRead = useCallback(() => {
+    setNotifications((prev) =>
+      prev.some((n) => !n.read) ? prev.map((n) => ({ ...n, read: true })) : prev,
+    );
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  const clear = useCallback(() => setNotifications([]), []);
+
+  const unreadCount = notifications.reduce((count, n) => count + (n.read ? 0 : 1), 0);
+
+  return (
+    <NotificationContext.Provider
+      value={{ notifications, unreadCount, addNotification, markRead, markAllRead, dismiss, clear }}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications(): NotificationContextType {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) throw new Error("useNotifications must be used within a NotificationProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary

- **`NotificationContext`** (`contexts/NotificationContext.tsx`): a general-purpose notification store, persisted to `localStorage`, with a `category` field (`transaction` / `risk` / `system` / `info`). API: `addNotification` (idempotent by `id`), `markRead`, `markAllRead`, `dismiss`, `clear`, plus `notifications`/`unreadCount`. Wired app-wide via a new `NotificationProvider` in `providers.tsx`.
- **`NotificationCenter`**: still polls on-chain events via the existing `useOnChainNotifications` hook (untouched), but now feeds them into the shared context store as `"transaction"`-category entries. The drawer groups entries by category, clicking a row marks it read, and a per-row dismiss (×) button removes it — in addition to the existing bulk "Mark all read".

## Acceptance criteria

- [x] Create `NotificationContext` with persistent storage
- [x] Build notification bell icon with unread count badge (existing bell/badge now reads from the new context)
- [x] Create notification drawer with categorized messages (grouped section headers per category)
- [x] Allow users to mark notifications as read/dismiss (per-row + bulk mark-read, per-row dismiss)

## Testing

Added `contexts/NotificationContext.test.tsx` (7 tests: add, idempotent add, markRead, markAllRead, dismiss, persistence across remount, outside-provider guard). Full suite: 80/80 passing (was 73 before this change — the on-chain notifications hook and its existing tests are untouched). `cd frontend && npm install --legacy-peer-deps && npm run build` builds cleanly.

@bbkenny, PR is ready for review!

Closes #95