### PR TITLE
[FE-46] Risk Scenario Simulator

### DIFF
--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -188,6 +188,7 @@ export default function Home() {
             <button type="button" className={`hover:text-foreground transition-colors rounded-sm ${focusVisibleClass}`}>{t('vaults')}</button>
             <button type="button" className={`hover:text-foreground transition-colors rounded-sm ${focusVisibleClass}`}>{t('swap')}</button>
             <Link href="/bridge" className={`hover:text-foreground transition-colors rounded-sm ${focusVisibleClass}`}>{t('bridge')}</Link>
+            <Link href="/simulate" className={`hover:text-foreground transition-colors rounded-sm ${focusVisibleClass}`}>{t('simulate')}</Link>
             <Link href="/settings" className={`hover:text-foreground transition-colors rounded-sm ${focusVisibleClass}`}>{t('settings')}</Link>
           </nav>
           <div className="flex items-center gap-2 sm:gap-4">

--- a/frontend/app/[locale]/simulate/page.tsx
+++ b/frontend/app/[locale]/simulate/page.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Info } from "lucide-react";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  Legend,
+  Cell,
+} from "recharts";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { useVaultContext } from "@/contexts/VaultContext";
+import { useCurrency } from "@/contexts/CurrencyContext";
+import { simulateScenario, type ScenarioResult } from "@/lib/ai/simulateScenario";
+
+interface RiskFactorInfo {
+  label: string;
+  description: string;
+}
+
+const RISK_FACTORS: Record<"fx" | "volatility", RiskFactorInfo> = {
+  fx: {
+    label: "FX Rate Shock",
+    description:
+      "A hypothetical, instantaneous move in the local currency's exchange rate against USD. Negative values simulate a devaluation — the scenario most relevant to holders of weak-currency stablecoins.",
+  },
+  volatility: {
+    label: "Volatility Shock",
+    description:
+      "A hypothetical spike in market volatility above baseline. Higher volatility widens the range of likely outcomes and increases the AI strategy's incentive to shift capital toward stable reserves.",
+  },
+};
+
+function InfoTooltip({ info }: { info: RiskFactorInfo }) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        className="p-0.5 rounded hover:bg-muted transition-colors"
+        aria-label={`What is ${info.label}?`}
+      >
+        <Info className="w-3.5 h-3.5 text-muted-foreground" />
+      </PopoverTrigger>
+      <PopoverContent className="p-3 text-xs leading-relaxed">
+        <p className="font-semibold mb-1">{info.label}</p>
+        <p className="text-muted-foreground">{info.description}</p>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function Slider({
+  label,
+  info,
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  label: string;
+  info: RiskFactorInfo;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1.5">
+        <div className="flex items-center gap-1.5">
+          <label className="text-sm font-medium">{label}</label>
+          <InfoTooltip info={info} />
+        </div>
+        <span className="text-sm font-mono font-semibold text-primary">
+          {value > 0 ? "+" : ""}
+          {value}%
+        </span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={1}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full accent-primary cursor-pointer"
+        aria-label={label}
+      />
+      <div className="flex justify-between text-[10px] text-muted-foreground mt-0.5">
+        <span>{min}%</span>
+        <span>{max}%</span>
+      </div>
+    </div>
+  );
+}
+
+export default function SimulatePage() {
+  const { baseBalance } = useVaultContext();
+  const { formatAmount } = useCurrency();
+
+  const [fxShockPercent, setFxShockPercent] = useState(-15);
+  const [volatilityShockPercent, setVolatilityShockPercent] = useState(20);
+  const [result, setResult] = useState<ScenarioResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const portfolioValueUsd = baseBalance > 0 ? baseBalance : 5_000;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setIsLoading(true);
+
+    const timeout = setTimeout(() => {
+      simulateScenario(
+        { fxShockPercent, volatilityShockPercent, portfolioValueUsd },
+        controller.signal,
+      )
+        .then(setResult)
+        .finally(() => setIsLoading(false));
+      // Debounced so dragging a slider doesn't fire a request per pixel.
+    }, 250);
+
+    return () => {
+      clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [fxShockPercent, volatilityShockPercent, portfolioValueUsd]);
+
+  const chartData = useMemo(() => {
+    if (!result) return [];
+    return [
+      {
+        name: "Without Aegis",
+        value: result.withoutAegis.projectedValueUsd,
+        fill: "hsl(var(--destructive))",
+      },
+      {
+        name: "With Aegis",
+        value: result.withAegis.projectedValueUsd,
+        fill: "hsl(var(--primary))",
+      },
+    ];
+  }, [result]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Dashboard
+        </Link>
+
+        <h1 className="text-2xl font-bold mb-1">Risk Scenario Simulator</h1>
+        <p className="text-sm text-muted-foreground mb-6">
+          Simulate how your portfolio would react to a hypothetical FX shock — with and without
+          Aegis&apos; automated hedging strategy.
+        </p>
+
+        <div className="bg-card border border-border rounded-xl p-4 sm:p-6 space-y-6 mb-6">
+          <Slider
+            label="FX Rate Shock"
+            info={RISK_FACTORS.fx}
+            value={fxShockPercent}
+            min={-50}
+            max={50}
+            onChange={setFxShockPercent}
+          />
+          <Slider
+            label="Volatility Shock"
+            info={RISK_FACTORS.volatility}
+            value={volatilityShockPercent}
+            min={0}
+            max={50}
+            onChange={setVolatilityShockPercent}
+          />
+        </div>
+
+        <div className="bg-card border border-border rounded-xl p-4 sm:p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Projected Portfolio Value
+            </h2>
+            {result && (
+              <span className="text-[10px] font-mono text-muted-foreground/70">
+                {result.source === "api" ? "AI_API" : "LOCAL_ESTIMATE"}
+              </span>
+            )}
+          </div>
+
+          {isLoading || !result ? (
+            <div className="h-64 flex items-center justify-center">
+              <div className="animate-spin h-6 w-6 border-4 border-primary border-t-transparent rounded-full" />
+            </div>
+          ) : (
+            <>
+              <div className="w-full h-64">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+                    <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                    <YAxis
+                      tick={{ fontSize: 12 }}
+                      tickFormatter={(v) => formatAmount(v)}
+                      width={80}
+                    />
+                    <RechartsTooltip formatter={(v) => formatAmount(Number(v))} />
+                    <Legend />
+                    <Bar dataKey="value" name="Projected value">
+                      {chartData.map((entry) => (
+                        <Cell key={entry.name} fill={entry.fill} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4 mt-4 pt-4 border-t border-border">
+                <div>
+                  <p className="text-xs text-muted-foreground">Without Aegis</p>
+                  <p className="text-lg font-bold">{formatAmount(result.withoutAegis.projectedValueUsd)}</p>
+                  <p
+                    className={`text-xs font-medium ${
+                      result.withoutAegis.changePercent < 0 ? "text-destructive" : "text-primary"
+                    }`}
+                  >
+                    {result.withoutAegis.changePercent > 0 ? "+" : ""}
+                    {result.withoutAegis.changePercent}%
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">With Aegis</p>
+                  <p className="text-lg font-bold">{formatAmount(result.withAegis.projectedValueUsd)}</p>
+                  <p
+                    className={`text-xs font-medium ${
+                      result.withAegis.changePercent < 0 ? "text-destructive" : "text-primary"
+                    }`}
+                  >
+                    {result.withAegis.changePercent > 0 ? "+" : ""}
+                    {result.withAegis.changePercent}%
+                  </p>
+                </div>
+              </div>
+
+              <p className="text-xs text-muted-foreground mt-4">
+                Under this scenario, the strategy would shift approximately{" "}
+                <span className="font-semibold text-foreground">{result.strategyShiftPercent}%</span>{" "}
+                of the portfolio toward hedges and stable reserves.
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 import { siteUrl } from "@/lib/siteConfig";
 import { routing } from "@/i18n/routing";
 
-const STATIC_ROUTES = ["", "/bridge", "/settings"];
+const STATIC_ROUTES = ["", "/bridge", "/settings", "/simulate"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();

--- a/frontend/lib/ai/simulateScenario.test.ts
+++ b/frontend/lib/ai/simulateScenario.test.ts
@@ -1,0 +1,50 @@
+import { simulateScenario } from "./simulateScenario";
+
+describe("simulateScenario (local fallback, no NEXT_PUBLIC_AI_API_URL configured)", () => {
+  it("applies the full FX shock to the unhedged projection", async () => {
+    const result = await simulateScenario({
+      fxShockPercent: -20,
+      volatilityShockPercent: 0,
+      portfolioValueUsd: 10_000,
+    });
+
+    expect(result.source).toBe("local");
+    expect(result.withoutAegis.changePercent).toBe(-20);
+    expect(result.withoutAegis.projectedValueUsd).toBe(8_000);
+  });
+
+  it("dampens the hedged projection relative to the unhedged one", async () => {
+    const result = await simulateScenario({
+      fxShockPercent: -30,
+      volatilityShockPercent: 20,
+      portfolioValueUsd: 10_000,
+    });
+
+    expect(Math.abs(result.withAegis.changePercent)).toBeLessThan(
+      Math.abs(result.withoutAegis.changePercent),
+    );
+    expect(result.strategyShiftPercent).toBeGreaterThan(0);
+  });
+
+  it("produces no shift and no impact for a zero shock", async () => {
+    const result = await simulateScenario({
+      fxShockPercent: 0,
+      volatilityShockPercent: 0,
+      portfolioValueUsd: 10_000,
+    });
+
+    expect(result.withoutAegis.projectedValueUsd).toBe(10_000);
+    expect(result.withAegis.projectedValueUsd).toBe(10_000);
+    expect(result.strategyShiftPercent).toBe(0);
+  });
+
+  it("caps the dampening factor at 70%", async () => {
+    const result = await simulateScenario({
+      fxShockPercent: -50,
+      volatilityShockPercent: 50,
+      portfolioValueUsd: 10_000,
+    });
+
+    expect(result.strategyShiftPercent).toBeLessThanOrEqual(70);
+  });
+});

--- a/frontend/lib/ai/simulateScenario.ts
+++ b/frontend/lib/ai/simulateScenario.ts
@@ -1,0 +1,93 @@
+const AI_API_URL = process.env.NEXT_PUBLIC_AI_API_URL;
+
+export interface ScenarioParams {
+  /** Hypothetical FX rate shock, in percent. Negative = local currency devalues. */
+  fxShockPercent: number;
+  /** Hypothetical volatility shock, in percent above baseline. */
+  volatilityShockPercent: number;
+  /** Starting portfolio value in USD, used to project the shocked outcome. */
+  portfolioValueUsd: number;
+}
+
+export interface ScenarioProjection {
+  /** Projected portfolio value under the shock, in USD. */
+  projectedValueUsd: number;
+  /** Change from the current portfolio value, in percent. */
+  changePercent: number;
+}
+
+export interface ScenarioResult {
+  withoutAegis: ScenarioProjection;
+  withAegis: ScenarioProjection;
+  /** Share of the strategy shifted into hedges/stable reserves in response to the shock, in percent. */
+  strategyShiftPercent: number;
+  source: "api" | "local";
+}
+
+/**
+ * Runs a "what-if" FX shock scenario against the current portfolio.
+ *
+ * Calls the backend AI API (NEXT_PUBLIC_AI_API_URL) when configured; falls
+ * back to a deterministic local approximation otherwise or if the call
+ * fails, mirroring the fallback pattern used for on-chain data elsewhere in
+ * this app (e.g. StrategyAllocationPie, useOnChainNotifications).
+ */
+export async function simulateScenario(
+  params: ScenarioParams,
+  signal?: AbortSignal,
+): Promise<ScenarioResult> {
+  if (AI_API_URL) {
+    try {
+      const res = await fetch(new URL("/api/simulate", AI_API_URL).toString(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params),
+        signal,
+      });
+      if (res.ok) {
+        return { ...((await res.json()) as Omit<ScenarioResult, "source">), source: "api" };
+      }
+    } catch {
+      // Network error, timeout, or backend unavailable — fall through to the
+      // local approximation below so the simulator still works offline/in dev.
+    }
+  }
+
+  return { ...computeLocalProjection(params), source: "local" };
+}
+
+/**
+ * Deterministic local approximation, used when no AI backend is configured
+ * (or it's unreachable). Not a real risk model — just enough to make the
+ * "what-if" tool interactive and directionally sensible:
+ *
+ * - Without Aegis: the portfolio absorbs the full FX shock directly.
+ * - With Aegis: the strategy shifts capital toward hedges/stable reserves in
+ *   proportion to the shock size, damping the impact by up to 70%.
+ */
+function computeLocalProjection(
+  params: ScenarioParams,
+): Omit<ScenarioResult, "source"> {
+  const { fxShockPercent, volatilityShockPercent, portfolioValueUsd } = params;
+
+  const rawImpactPercent = fxShockPercent - volatilityShockPercent * 0.1;
+  const withoutValue = portfolioValueUsd * (1 + rawImpactPercent / 100);
+
+  // Larger shocks trigger a larger defensive shift, capped at 70% dampening.
+  const shockMagnitude = Math.min(Math.abs(fxShockPercent) + Math.abs(volatilityShockPercent), 100);
+  const dampeningFactor = Math.min(0.7, shockMagnitude / 100);
+  const hedgedImpactPercent = rawImpactPercent * (1 - dampeningFactor);
+  const withValue = portfolioValueUsd * (1 + hedgedImpactPercent / 100);
+
+  return {
+    withoutAegis: {
+      projectedValueUsd: Math.round(withoutValue),
+      changePercent: Number(rawImpactPercent.toFixed(2)),
+    },
+    withAegis: {
+      projectedValueUsd: Math.round(withValue),
+      changePercent: Number(hedgedImpactPercent.toFixed(2)),
+    },
+    strategyShiftPercent: Number((dampeningFactor * 100).toFixed(1)),
+  };
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -31,6 +31,7 @@
     "referrals": "Referrals",
     "vaults": "Vaults",
     "swap": "Swap",
+    "simulate": "Simulate",
     "settings": "Settings",
     "deposit": "Deposit",
     "withdraw": "Withdraw",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -31,6 +31,7 @@
     "referrals": "Referidos",
     "vaults": "Bóvedas",
     "swap": "Intercambiar",
+    "simulate": "Simular",
     "settings": "Ajustes",
     "deposit": "Depositar",
     "withdraw": "Retirar",


### PR DESCRIPTION
## Summary

Adds a `/simulate` "what-if" tool for modeling portfolio reaction to a hypothetical FX shock.

- **Slider inputs**: FX Rate Shock (-50% to +50%) and Volatility Shock (0% to 50%), each with an educational tooltip (via the existing `Popover` component) explaining the risk factor.
- **Backend AI API call**: `lib/ai/simulateScenario.ts` POSTs the hypothetical parameters to `NEXT_PUBLIC_AI_API_URL` when configured, falling back to a deterministic local approximation when it isn't (or the call fails) — mirroring the same try-then-fallback pattern already used for on-chain data elsewhere in this app (`StrategyAllocationPie`, `useOnChainNotifications`).
- **Comparison chart**: a bar chart of projected portfolio value — "Without Aegis" (the shock applied directly) vs. "With Aegis" (dampened by a simulated shift toward hedges/stable reserves) — plus the numeric projected values, % change, and the resulting strategy-shift percentage.

## Acceptance criteria

- [x] Create `/simulate` route with slider inputs for FX rate changes
- [x] Call backend AI API with hypothetical parameters
- [x] Display projected portfolio value and strategy shift
- [x] Show comparison chart: "Without Aegis" vs. "With Aegis"
- [x] Add educational tooltips explaining risk factors

## Testing

Added `lib/ai/simulateScenario.test.ts` (4 tests: full unhedged impact, dampened hedged impact vs. unhedged, zero-shock no-op, 70% dampening cap). Full suite: 77/77 passing. `cd frontend && npm install --legacy-peer-deps && npm run build` builds cleanly — `/[locale]/simulate` appears as a built route.

@bbkenny, PR is ready for review!

Closes #111