### PR TITLE
[FE-13-FollowUp] Fetch live NGN/USD exchange rate instead of hardcode…

### DIFF
--- a/frontend/contexts/CurrencyContext.test.tsx
+++ b/frontend/contexts/CurrencyContext.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { CurrencyProvider, useCurrency } from "./CurrencyContext";
+import { FALLBACK_USD_TO_NGN_RATE } from "@/lib/currency/exchangeRate";
+
+describe("CurrencyContext", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("adopts the live rate once the fetch resolves", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: "success", rates: { NGN: 1500 } }),
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useCurrency(), {
+      wrapper: CurrencyProvider,
+    });
+
+    await waitFor(() => expect(result.current.rate).toBe(1500));
+    expect(result.current.rateSource).toBe("api");
+    expect(result.current.isLoadingRate).toBe(false);
+  });
+
+  it("formats NGN amounts using the live rate, not the old hardcoded constant", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: "success", rates: { NGN: 2000 } }),
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useCurrency(), {
+      wrapper: CurrencyProvider,
+    });
+
+    await waitFor(() => expect(result.current.rate).toBe(2000));
+
+    act(() => {
+      if (result.current.currency !== "NGN") result.current.toggleCurrency();
+    });
+
+    await waitFor(() => expect(result.current.currency).toBe("NGN"));
+    expect(result.current.formatAmount(1)).toContain("2,000");
+  });
+
+  it("keeps the fallback rate when the API is unreachable", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("offline")) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useCurrency(), {
+      wrapper: CurrencyProvider,
+    });
+
+    await waitFor(() => expect(result.current.isLoadingRate).toBe(false));
+    expect(result.current.rate).toBe(FALLBACK_USD_TO_NGN_RATE);
+    expect(result.current.rateSource).toBe("fallback");
+  });
+});

--- a/frontend/contexts/CurrencyContext.tsx
+++ b/frontend/contexts/CurrencyContext.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { createContext, useContext, useState, useCallback, ReactNode } from "react";
+import { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from "react";
+import { fetchUsdToNgnRate, FALLBACK_USD_TO_NGN_RATE } from "@/lib/currency/exchangeRate";
 
-/** Fixed conversion factor: 1 USD = 1 600 NGN (update via env or API as needed). */
-export const USD_TO_NGN_RATE = 1_600;
+/** How often to re-fetch the live rate while the app is open. */
+const POLL_INTERVAL_MS = 5 * 60_000;
 
 type Currency = "USD" | "NGN";
 
@@ -13,13 +14,44 @@ interface CurrencyContextValue {
   /** Format a USD-denominated value into the active currency string. */
   formatAmount: (usdValue: number) => string;
   symbol: string;
+  /** Live USD→NGN rate (1 USD = `rate` NGN), or the fallback if unavailable. */
   rate: number;
+  /** Whether `rate` came from the live API or the offline fallback constant. */
+  rateSource: "api" | "fallback";
+  isLoadingRate: boolean;
 }
 
 const CurrencyContext = createContext<CurrencyContextValue | null>(null);
 
 export function CurrencyProvider({ children }: { children: ReactNode }) {
   const [currency, setCurrency] = useState<Currency>("USD");
+  const [rate, setRate] = useState<number>(FALLBACK_USD_TO_NGN_RATE);
+  const [rateSource, setRateSource] = useState<"api" | "fallback">("fallback");
+  const [isLoadingRate, setIsLoadingRate] = useState(true);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const controller = new AbortController();
+
+    const loadRate = async () => {
+      setIsLoadingRate(true);
+      const result = await fetchUsdToNgnRate(controller.signal);
+      if (!mountedRef.current) return;
+      setRate(result.rate);
+      setRateSource(result.source);
+      setIsLoadingRate(false);
+    };
+
+    loadRate();
+    const intervalId = setInterval(loadRate, POLL_INTERVAL_MS);
+
+    return () => {
+      mountedRef.current = false;
+      controller.abort();
+      clearInterval(intervalId);
+    };
+  }, []);
 
   const toggleCurrency = useCallback(
     () => setCurrency((c) => (c === "USD" ? "NGN" : "USD")),
@@ -30,7 +62,7 @@ export function CurrencyProvider({ children }: { children: ReactNode }) {
 
   const formatAmount = useCallback(
     (usdValue: number): string => {
-      const converted = currency === "NGN" ? usdValue * USD_TO_NGN_RATE : usdValue;
+      const converted = currency === "NGN" ? usdValue * rate : usdValue;
       return new Intl.NumberFormat(currency === "NGN" ? "en-NG" : "en-US", {
         style: "currency",
         currency,
@@ -38,12 +70,12 @@ export function CurrencyProvider({ children }: { children: ReactNode }) {
         minimumFractionDigits: 2,
       }).format(converted);
     },
-    [currency],
+    [currency, rate],
   );
 
   return (
     <CurrencyContext.Provider
-      value={{ currency, toggleCurrency, formatAmount, symbol, rate: USD_TO_NGN_RATE }}
+      value={{ currency, toggleCurrency, formatAmount, symbol, rate, rateSource, isLoadingRate }}
     >
       {children}
     </CurrencyContext.Provider>

--- a/frontend/lib/currency/exchangeRate.test.ts
+++ b/frontend/lib/currency/exchangeRate.test.ts
@@ -1,0 +1,63 @@
+import { fetchUsdToNgnRate, FALLBACK_USD_TO_NGN_RATE } from "./exchangeRate";
+
+describe("fetchUsdToNgnRate", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("returns the live NGN rate on a successful response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: "success", rates: { NGN: 1550.25 } }),
+    }) as unknown as typeof fetch;
+
+    const result = await fetchUsdToNgnRate();
+
+    expect(result).toEqual({ rate: 1550.25, source: "api" });
+  });
+
+  it("falls back to the constant when the API responds with an error status", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof fetch;
+
+    const result = await fetchUsdToNgnRate();
+
+    expect(result).toEqual({ rate: FALLBACK_USD_TO_NGN_RATE, source: "fallback" });
+  });
+
+  it("falls back to the constant when the request throws (network error)", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+
+    const result = await fetchUsdToNgnRate();
+
+    expect(result).toEqual({ rate: FALLBACK_USD_TO_NGN_RATE, source: "fallback" });
+  });
+
+  it("falls back to the constant when the response is missing the NGN rate", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: "success", rates: { EUR: 0.9 } }),
+    }) as unknown as typeof fetch;
+
+    const result = await fetchUsdToNgnRate();
+
+    expect(result).toEqual({ rate: FALLBACK_USD_TO_NGN_RATE, source: "fallback" });
+  });
+
+  it("falls back to the constant when the API reports a non-success result", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: "error", rates: { NGN: 1550.25 } }),
+    }) as unknown as typeof fetch;
+
+    const result = await fetchUsdToNgnRate();
+
+    expect(result).toEqual({ rate: FALLBACK_USD_TO_NGN_RATE, source: "fallback" });
+  });
+});

--- a/frontend/lib/currency/exchangeRate.ts
+++ b/frontend/lib/currency/exchangeRate.ts
@@ -1,0 +1,54 @@
+/**
+ * Fallback conversion factor used when the live rate can't be fetched
+ * (offline, API down, or request timeout). Mirrors the previous hardcoded
+ * FE-13 constant so behavior degrades gracefully instead of breaking.
+ */
+export const FALLBACK_USD_TO_NGN_RATE = 1_600;
+
+const EXCHANGE_RATE_API_URL =
+  process.env.NEXT_PUBLIC_EXCHANGE_RATE_API_URL ?? "https://open.er-api.com/v6/latest/USD";
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+export interface ExchangeRateResult {
+  /** Amount of NGN equal to 1 USD. */
+  rate: number;
+  source: "api" | "fallback";
+}
+
+interface OpenErApiResponse {
+  result: string;
+  rates: Record<string, number>;
+}
+
+/**
+ * Fetches the live USD → NGN exchange rate.
+ *
+ * Falls back to FALLBACK_USD_TO_NGN_RATE on any network error, timeout, or
+ * malformed response, mirroring the fallback pattern used elsewhere in this
+ * app (e.g. simulateScenario, fetchBridgeQuote) so the UI keeps working
+ * offline/in dev even without a configured API.
+ */
+export async function fetchUsdToNgnRate(signal?: AbortSignal): Promise<ExchangeRateResult> {
+  const controller = new AbortController();
+  const timerId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  signal?.addEventListener("abort", () => controller.abort());
+
+  try {
+    const res = await fetch(EXCHANGE_RATE_API_URL, { signal: controller.signal });
+    if (!res.ok) throw new Error(`Exchange rate API error ${res.status}`);
+
+    const data = (await res.json()) as OpenErApiResponse;
+    const rate = data?.rates?.NGN;
+
+    if (data.result !== "success" || typeof rate !== "number" || !Number.isFinite(rate) || rate <= 0) {
+      throw new Error("Malformed exchange rate response");
+    }
+
+    return { rate, source: "api" };
+  } catch {
+    return { rate: FALLBACK_USD_TO_NGN_RATE, source: "fallback" };
+  } finally {
+    clearTimeout(timerId);
+  }
+}


### PR DESCRIPTION
## Summary
- The previous FE-13 implementation hardcoded `1 USD = 1,600 NGN` in `CurrencyContext.tsx`. This replaces the constant with a live NGN/USD rate fetched from a free, no-key exchange rate API (open.er-api.com), refreshed every 5 minutes.
- Added `lib/currency/exchangeRate.ts`: a `fetchUsdToNgnRate()` helper that fetches the live rate with an 8s timeout, and falls back to the old `1,600` constant on any network error, timeout, or malformed response — so the app degrades gracefully instead of breaking when offline or in dev. The API URL can be overridden via `NEXT_PUBLIC_EXCHANGE_RATE_API_URL`.
- `CurrencyContext.tsx` now fetches the rate on mount and polls every 5 minutes, exposing `rate`, `rateSource` (`"api" | "fallback"`), and `isLoadingRate` from `useCurrency()`. `formatAmount` now converts using this live `rate` instead of the removed constant.
- Added tests: `lib/currency/exchangeRate.test.ts` (fetch success / HTTP error / network error / malformed response / non-success result) and `contexts/CurrencyContext.test.tsx` (adopts live rate, formats amounts with it, falls back when the API is unreachable).

## Test plan
- [x] `npm install --legacy-peer-deps && npm test` — all 92 tests pass (8 new)
- [x] `npm run build` — compiles and type-checks cleanly
- [x] Manually verified the live API response shape against `https://open.er-api.com/v6/latest/USD`

Closes #97

@bbkenny, PR is ready for review!