### PR TITLE
[FE-27] Real-time Price Tracker

### DIFF
--- a/frontend/app/[locale]/bridge/page.tsx
+++ b/frontend/app/[locale]/bridge/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/com
 import { CurrencySwitch } from "@/components/CurrencySwitch";
 import { NetworkSwitch } from "@/components/NetworkSwitch";
 import { BridgeForm } from "@/components/BridgeForm";
+import { AssetPriceTracker } from "@/components/AssetPriceTracker";
 import { BridgeTransactionMonitor } from "@/components/bridge/BridgeTransactionMonitor";
 import { useBridgeTransactions } from "@/hooks/useBridgeTransactions";
 import type { AddTransactionParams } from "@/hooks/useBridgeTransactions";
@@ -79,6 +80,9 @@ export default function BridgePage() {
                 <BridgeForm onSubmit={handleBridgeSubmit} />
               </CardContent>
             </Card>
+
+            {/* Live asset prices */}
+            <AssetPriceTracker />
 
             {/* Info card */}
             <Card>

--- a/frontend/components/AssetPriceTracker.tsx
+++ b/frontend/components/AssetPriceTracker.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { TrendingUp } from "lucide-react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { StaleDataIndicator } from "@/components/StaleDataIndicator";
+import { usePriceTracker } from "@/hooks/usePriceTracker";
+import { BRIDGE_TOKENS } from "@/lib/bridge/allbridge";
+
+const TRACKED_ASSETS: { symbol: string; coingeckoId: string }[] = [
+  { symbol: "XLM", coingeckoId: "stellar" },
+  ...BRIDGE_TOKENS.filter((t) => t.coingeckoId).map((t) => ({
+    symbol: t.symbol,
+    coingeckoId: t.coingeckoId as string,
+  })),
+];
+
+const TRACKED_IDS = TRACKED_ASSETS.map((a) => a.coingeckoId);
+
+function formatUsd(price: number): string {
+  return `$${price.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  })}`;
+}
+
+/** Live USD spot prices for the assets supported by the bridge, polled via usePriceTracker. */
+export function AssetPriceTracker() {
+  const { prices, loading, error, freshnessLevel, lastUpdatedLabel } = usePriceTracker({
+    ids: TRACKED_IDS,
+  });
+
+  return (
+    <Card>
+      <CardHeader className="border-b border-border/50">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <TrendingUp className="h-4 w-4 text-primary" aria-hidden="true" />
+            Live Asset Prices
+          </CardTitle>
+          {!loading && (
+            <StaleDataIndicator freshnessLevel={freshnessLevel} lastUpdatedLabel={lastUpdatedLabel} />
+          )}
+        </div>
+        <CardDescription>Live USD spot prices, polled every 30 seconds.</CardDescription>
+      </CardHeader>
+      <CardContent className="pt-5">
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Fetching live prices…</p>
+        ) : (
+          <ul className="space-y-2">
+            {TRACKED_ASSETS.map(({ symbol, coingeckoId }) => {
+              const price = prices[coingeckoId];
+              return (
+                <li key={coingeckoId} className="flex items-center justify-between text-sm">
+                  <span className="font-medium">{symbol}</span>
+                  <span className="font-mono text-muted-foreground" aria-live="polite">
+                    {price !== undefined ? formatUsd(price) : "—"}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {error && !loading && (
+          <p className="mt-3 text-xs text-amber-600 dark:text-amber-400" role="status">
+            Live prices unavailable — showing last known values.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/hooks/usePriceTracker.test.ts
+++ b/frontend/hooks/usePriceTracker.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { usePriceTracker } from "./usePriceTracker";
+import type { SpotPrices } from "@/lib/prices/coingecko";
+
+const fetchSpotPrices = jest.fn<Promise<SpotPrices>, any[]>();
+jest.mock("@/lib/prices/coingecko", () => ({
+  fetchSpotPrices: (...args: any[]) => fetchSpotPrices(...args),
+}));
+
+describe("usePriceTracker", () => {
+  beforeEach(() => {
+    fetchSpotPrices.mockReset();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts loading and resolves with the fetched prices", async () => {
+    fetchSpotPrices.mockResolvedValue({ stellar: 0.17 });
+
+    const { result } = renderHook(() => usePriceTracker({ ids: ["stellar"] }));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.prices).toEqual({ stellar: 0.17 });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("polls again after pollIntervalMs and updates prices", async () => {
+    fetchSpotPrices.mockResolvedValueOnce({ stellar: 0.17 });
+
+    const { result } = renderHook(() =>
+      usePriceTracker({ ids: ["stellar"], pollIntervalMs: 1000 }),
+    );
+
+    await waitFor(() => expect(result.current.prices).toEqual({ stellar: 0.17 }));
+
+    fetchSpotPrices.mockResolvedValueOnce({ stellar: 0.18 });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.prices).toEqual({ stellar: 0.18 }));
+    expect(fetchSpotPrices).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the last known-good prices and sets error when a poll fails", async () => {
+    fetchSpotPrices.mockResolvedValueOnce({ stellar: 0.17 });
+
+    const { result } = renderHook(() =>
+      usePriceTracker({ ids: ["stellar"], pollIntervalMs: 1000 }),
+    );
+
+    await waitFor(() => expect(result.current.prices).toEqual({ stellar: 0.17 }));
+
+    fetchSpotPrices.mockRejectedValueOnce(new Error("network down"));
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe("network down"));
+    expect(result.current.prices).toEqual({ stellar: 0.17 });
+  });
+
+  it("does not fetch when disabled", async () => {
+    fetchSpotPrices.mockResolvedValue({ stellar: 0.17 });
+
+    const { result } = renderHook(() =>
+      usePriceTracker({ ids: ["stellar"], enabled: false }),
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(fetchSpotPrices).not.toHaveBeenCalled();
+    expect(result.current.prices).toEqual({});
+  });
+
+  it("refresh() triggers an immediate re-fetch", async () => {
+    fetchSpotPrices.mockResolvedValueOnce({ stellar: 0.17 });
+
+    const { result } = renderHook(() =>
+      usePriceTracker({ ids: ["stellar"], pollIntervalMs: 60_000 }),
+    );
+
+    await waitFor(() => expect(result.current.prices).toEqual({ stellar: 0.17 }));
+
+    fetchSpotPrices.mockResolvedValueOnce({ stellar: 0.2 });
+
+    await act(async () => {
+      result.current.refresh();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.prices).toEqual({ stellar: 0.2 }));
+  });
+});

--- a/frontend/hooks/usePriceTracker.ts
+++ b/frontend/hooks/usePriceTracker.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { fetchSpotPrices, type SpotPrices } from "@/lib/prices/coingecko";
+import { useStaleData, type FreshnessLevel } from "./useStaleData";
+
+/** How often to re-poll for live prices while tracking is enabled. */
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+export interface UsePriceTrackerOptions {
+  /** CoinGecko asset ids to track, e.g. ["stellar", "usd-coin"]. */
+  ids: string[];
+  pollIntervalMs?: number;
+  enabled?: boolean;
+}
+
+export interface UsePriceTrackerResult {
+  /** Map of CoinGecko id → last known USD spot price. */
+  prices: SpotPrices;
+  /** True only until the first fetch attempt settles. */
+  loading: boolean;
+  /** Set when the most recent poll failed; `prices` still holds the last known-good values. */
+  error: string | null;
+  freshnessLevel: FreshnessLevel;
+  lastUpdatedLabel: string;
+  /** Manually re-poll immediately. */
+  refresh: () => void;
+}
+
+/**
+ * Polls CoinGecko's public simple-price endpoint for live USD spot prices.
+ *
+ * On a failed poll, keeps showing the last known-good prices and surfaces the
+ * failure via `error` + the staleness fields instead of clearing the UI —
+ * mirroring the keep-last-good-data pattern used by useRealtimeVault and
+ * useOnChainNotifications elsewhere in this app.
+ */
+export function usePriceTracker({
+  ids,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  enabled = true,
+}: UsePriceTrackerOptions): UsePriceTrackerResult {
+  const [prices, setPrices] = useState<SpotPrices>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { freshnessLevel, lastUpdatedLabel, markFetched } = useStaleData();
+
+  const mountedRef = useRef(true);
+  const idsRef = useRef(ids);
+  idsRef.current = ids;
+
+  // Stable, content-based key so the effect only restarts when the actual
+  // set of ids changes, not on every render that passes a new array literal.
+  const idsKey = [...ids].sort().join(",");
+
+  const fetchPrices = useCallback(
+    async (signal?: AbortSignal) => {
+      try {
+        const result = await fetchSpotPrices(idsRef.current, signal);
+        if (!mountedRef.current) return;
+        setPrices(result);
+        setError(null);
+        markFetched();
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setError(err instanceof Error ? err.message : "Failed to fetch live prices");
+      } finally {
+        if (mountedRef.current) setLoading(false);
+      }
+    },
+    [markFetched],
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (!enabled || idsRef.current.length === 0) {
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    fetchPrices(controller.signal);
+
+    const intervalId = setInterval(() => fetchPrices(controller.signal), pollIntervalMs);
+
+    return () => {
+      mountedRef.current = false;
+      controller.abort();
+      clearInterval(intervalId);
+    };
+    // idsKey (not ids) intentionally drives re-subscription; see idsRef above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idsKey, enabled, pollIntervalMs, fetchPrices]);
+
+  const refresh = useCallback(() => {
+    fetchPrices();
+  }, [fetchPrices]);
+
+  return { prices, loading, error, freshnessLevel, lastUpdatedLabel, refresh };
+}

--- a/frontend/lib/prices/coingecko.test.ts
+++ b/frontend/lib/prices/coingecko.test.ts
@@ -1,0 +1,69 @@
+import { fetchSpotPrices } from "./coingecko";
+
+describe("fetchSpotPrices", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("returns an empty object without calling fetch when no ids are given", async () => {
+    global.fetch = jest.fn();
+
+    const result = await fetchSpotPrices([]);
+
+    expect(result).toEqual({});
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns live USD prices for every requested id on success", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          stellar: { usd: 0.17 },
+          "usd-coin": { usd: 0.999 },
+        }),
+    }) as unknown as typeof fetch;
+
+    const result = await fetchSpotPrices(["stellar", "usd-coin"]);
+
+    expect(result).toEqual({ stellar: 0.17, "usd-coin": 0.999 });
+  });
+
+  it("omits ids missing from the response instead of throwing, as long as at least one resolves", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ stellar: { usd: 0.17 } }),
+    }) as unknown as typeof fetch;
+
+    const result = await fetchSpotPrices(["stellar", "unknown-token"]);
+
+    expect(result).toEqual({ stellar: 0.17 });
+  });
+
+  it("throws when the API responds with an error status", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }) as unknown as typeof fetch;
+
+    await expect(fetchSpotPrices(["stellar"])).rejects.toThrow("CoinGecko API error 500");
+  });
+
+  it("throws when the request fails outright (network error)", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("offline")) as unknown as typeof fetch;
+
+    await expect(fetchSpotPrices(["stellar"])).rejects.toThrow();
+  });
+
+  it("throws when none of the requested ids are present in the response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof fetch;
+
+    await expect(fetchSpotPrices(["stellar"])).rejects.toThrow("Malformed price response");
+  });
+});

--- a/frontend/lib/prices/coingecko.ts
+++ b/frontend/lib/prices/coingecko.ts
@@ -1,0 +1,52 @@
+const COINGECKO_API_URL =
+  process.env.NEXT_PUBLIC_COINGECKO_API_URL ?? "https://api.coingecko.com/api/v3";
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+/** Map of CoinGecko asset id → live USD spot price. */
+export type SpotPrices = Record<string, number>;
+
+interface SimplePriceRaw {
+  [id: string]: { usd?: number } | undefined;
+}
+
+/**
+ * Fetches live USD spot prices for the given CoinGecko asset ids from the
+ * public `simple/price` endpoint (no API key required).
+ *
+ * Throws on network error, timeout, non-2xx response, or a response missing
+ * every requested id. Callers are expected to catch this and keep showing
+ * their last known-good prices (see usePriceTracker) rather than clearing
+ * the UI on a transient failure.
+ */
+export async function fetchSpotPrices(ids: string[], signal?: AbortSignal): Promise<SpotPrices> {
+  if (ids.length === 0) return {};
+
+  const controller = new AbortController();
+  const timerId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  signal?.addEventListener("abort", () => controller.abort());
+
+  try {
+    const url = `${COINGECKO_API_URL}/simple/price?ids=${encodeURIComponent(ids.join(","))}&vs_currencies=usd`;
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`CoinGecko API error ${res.status}`);
+
+    const data = (await res.json()) as SimplePriceRaw;
+    const prices: SpotPrices = {};
+
+    for (const id of ids) {
+      const price = data[id]?.usd;
+      if (typeof price === "number" && Number.isFinite(price) && price > 0) {
+        prices[id] = price;
+      }
+    }
+
+    if (Object.keys(prices).length === 0) {
+      throw new Error("Malformed price response");
+    }
+
+    return prices;
+  } finally {
+    clearTimeout(timerId);
+  }
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -16,7 +16,7 @@ export default function middleware(request: any) {
     form-action 'self';
     frame-ancestors 'none';
     upgrade-insecure-requests;
-    connect-src 'self' https://horizon.stellar.org https://horizon-testnet.stellar.org;
+    connect-src 'self' https://horizon.stellar.org https://horizon-testnet.stellar.org https://api.coingecko.com;
   `;
 
   const contentSecurityPolicyHeaderValue = cspHeader


### PR DESCRIPTION
## Summary
- [FE-27] Real-time Price Tracker — adds a `usePriceTracker` hook (`hooks/usePriceTracker.ts`) that polls for live asset prices and keeps the UI working smoothly with real-time data.
- Added `lib/prices/coingecko.ts`: a `fetchSpotPrices()` helper hitting CoinGecko's free, no-key `simple/price` endpoint. Throws on network error/timeout/malformed response so the hook can decide how to handle it.
- `usePriceTracker` polls every 30s (configurable via `pollIntervalMs`), and on a failed poll **keeps showing the last known-good prices** while surfacing the failure through `error` and a stale/aging/fresh `freshnessLevel` — the same keep-last-good-data pattern already used by `useRealtimeVault` and `useOnChainNotifications` in this app, rather than blanking the UI on a transient failure.
- Wired it into the Bridge page via a new `AssetPriceTracker` card showing live USD prices for XLM and the bridgeable tokens (USDC/USDT/EURC, using the `coingeckoId`s already present on `BRIDGE_TOKENS`). It reuses the existing `StaleDataIndicator` component (previously unused) to show a "Live/Aging/Stale · updated Xs ago" badge.
- **Also fixes a CSP gap**: `middleware.ts`'s `connect-src` didn't allow `api.coingecko.com`, so the browser would silently block the fetch. Caught this by actually loading the page in a headless browser rather than just running the test suite — confirmed working after the fix (see screenshot).

## Test plan
- [x] `npm install --legacy-peer-deps && npm test` — all 95 tests pass (11 new, covering fetch success/HTTP error/network error/malformed response, polling, stale-on-failure behavior, disabled state, and manual refresh)
- [x] `npm run build` — compiles and type-checks cleanly
- [x] Verified in a real headless browser (not just unit tests) that the CSP change unblocks the live fetch and the Bridge page renders live prices:

`XLM $0.1731 · USDC $0.9997 · USDT $0.999 · EURC $1.14` with a green "Live · Just now" badge.

Closes #99

@bbkenny, PR is ready for review!