### PR TITLE
feat: add Performance Attribution component (FE-45)

### DIFF
--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -25,6 +25,11 @@ const RiskChart = dynamic(() => import('../../components/RiskChart').then(mod =>
   ssr: false,
   loading: () => <div className="min-h-[200px] flex items-center justify-center animate-pulse"><p className="text-muted-foreground">Loading risk data...</p></div>
 });
+
+const PerformanceAttribution = dynamic(() => import('../../components/PerformanceAttribution').then(mod => mod.PerformanceAttribution), {
+  ssr: false,
+  loading: () => <div className="w-full min-h-[300px] bg-card rounded-xl border border-border animate-pulse flex items-center justify-center"><p className="text-muted-foreground">Loading attribution...</p></div>
+});
 import { RiskBadge } from "../../components/RiskBadge";
 import { WithdrawTab } from "../../components/WithdrawTab";
 import { DepositTab } from "../../components/DepositTab";
@@ -318,6 +323,7 @@ export default function Home() {
               {/* Sidebar / Stats */}
               <div className="space-y-6">
                 <AiInsightStream />
+                <PerformanceAttribution />
                 <div className="bg-gradient-to-br from-primary to-primary/80 text-primary-foreground p-8 rounded-3xl shadow-2xl shadow-primary/20 relative overflow-hidden">
                    <div className="relative z-10">
                       <h2 className="text-2xl font-bold mb-2">Aegis Guard</h2>

--- a/frontend/components/PerformanceAttribution.tsx
+++ b/frontend/components/PerformanceAttribution.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { fetchAttribution, type AttributionPeriod, type AttributionSource } from "@/lib/ai/fetchAttribution";
+import { PieChartIcon, RefreshCw } from "lucide-react";
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: AttributionSource }>;
+}
+
+function CustomTooltip({ active, payload }: CustomTooltipProps) {
+  if (active && payload && payload.length) {
+    const source = payload[0].payload;
+    return (
+      <div className="bg-background border border-border p-3 rounded-lg shadow-xl space-y-1">
+        <p className="text-sm font-medium text-foreground">{source.name}</p>
+        <p className="text-xs text-muted-foreground">
+          Yield: ${source.value.toLocaleString()}
+        </p>
+        <p className="text-xs font-bold text-primary">
+          {source.percentage}% of total
+        </p>
+      </div>
+    );
+  }
+  return null;
+}
+
+const PERIODS: { key: AttributionPeriod; label: string }[] = [
+  { key: "1W", label: "1W" },
+  { key: "1M", label: "1M" },
+  { key: "3M", label: "3M" },
+  { key: "All", label: "All" },
+];
+
+export const PerformanceAttribution = React.memo(function PerformanceAttribution() {
+  const [period, setPeriod] = useState<AttributionPeriod>("1M");
+  const [data, setData] = useState<AttributionSource[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchAttribution(period);
+      setData(result.sources);
+      setTotal(result.total);
+    } catch {
+      setError("Failed to load attribution data");
+    } finally {
+      setLoading(false);
+    }
+  }, [period]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="w-full min-h-[300px] bg-card rounded-xl border border-border animate-pulse flex items-center justify-center">
+        <p className="text-muted-foreground">Loading attribution data...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full bg-card rounded-xl border border-border p-4 sm:p-6 shadow-sm">
+      <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-4 md:mb-6 gap-3 md:gap-4">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <PieChartIcon className="w-5 h-5 text-primary" />
+            <h3 className="text-lg font-semibold text-foreground">
+              Performance Attribution
+            </h3>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Yield breakdown by return source
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={load}
+            className="p-2 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Refresh attribution data"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </button>
+
+          <div className="flex bg-muted p-1 rounded-lg">
+            {PERIODS.map(({ key, label }) => (
+              <button
+                key={key}
+                type="button"
+                aria-pressed={period === key}
+                onClick={() => setPeriod(key)}
+                className={`px-3 py-1 text-xs font-medium rounded-md transition-all ${
+                  period === key
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="flex flex-col items-center justify-center min-h-[200px] gap-2">
+          <p className="text-sm text-muted-foreground">{error}</p>
+          <button
+            type="button"
+            onClick={load}
+            className="text-sm text-primary hover:underline"
+          >
+            Try again
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Total yield:{" "}
+            <span className="text-lg font-bold text-green-500">
+              +${total.toLocaleString()}
+            </span>
+          </p>
+
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart
+              data={data}
+              margin={{ top: 5, right: 10, left: 0, bottom: 0 }}
+              layout="vertical"
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                horizontal
+                stroke="hsl(var(--muted-foreground))"
+                opacity={0.1}
+              />
+              <XAxis
+                type="number"
+                domain={[0, 100]}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
+                tickFormatter={(value) => `${value}%`}
+              />
+              <YAxis
+                type="category"
+                dataKey="name"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
+                width={130}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Bar
+                dataKey="percentage"
+                radius={[0, 4, 4, 0]}
+                animationDuration={1000}
+                label={{
+                  position: "right",
+                  formatter: (label) => `${label}%`,
+                  fill: "hsl(var(--muted-foreground))",
+                  fontSize: 11,
+                }}
+              >
+                {data.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/frontend/lib/ai/fetchAttribution.ts
+++ b/frontend/lib/ai/fetchAttribution.ts
@@ -1,0 +1,96 @@
+const AI_API_URL = process.env.NEXT_PUBLIC_AI_API_URL;
+
+export type AttributionPeriod = "1W" | "1M" | "3M" | "All";
+
+export interface AttributionSource {
+  name: string;
+  value: number;
+  percentage: number;
+  color: string;
+}
+
+export interface AttributionData {
+  total: number;
+  sources: AttributionSource[];
+}
+
+/**
+ * Fetches portfolio yield breakdown from the backend AI API.
+ *
+ * Calls NEXT_PUBLIC_AI_API_URL/api/attribution when configured; falls back to
+ * local mock data otherwise or on failure.
+ */
+export async function fetchAttribution(
+  period: AttributionPeriod,
+  signal?: AbortSignal,
+): Promise<AttributionData> {
+  if (AI_API_URL) {
+    try {
+      const res = await fetch(
+        new URL(`/api/attribution?period=${period}`, AI_API_URL).toString(),
+        { signal },
+      );
+      if (res.ok) {
+        const json = (await res.json()) as AttributionData;
+        return { ...json, sources: normalizeSources(json.sources) };
+      }
+    } catch {
+      // Fall through to local mock
+    }
+  }
+
+  return computeLocalAttribution(period);
+}
+
+function normalizeSources(sources: AttributionSource[]): AttributionSource[] {
+  const total = sources.reduce((sum, s) => sum + s.value, 0);
+  if (total <= 0) return sources;
+  return sources.map((s) => ({
+    ...s,
+    percentage: Math.round((s.value / total) * 10000) / 100,
+  }));
+}
+
+function computeLocalAttribution(
+  period: AttributionPeriod,
+): AttributionData {
+  const multiplier = period === "1W" ? 1 : period === "1M" ? 4.3 : period === "3M" ? 13 : 52;
+
+  const sources: AttributionSource[] = [
+    {
+      name: "Stablecoin Yield",
+      value: Math.round(42 * multiplier * 10) / 10,
+      percentage: 35,
+      color: "hsl(142, 76%, 36%)",
+    },
+    {
+      name: "LP Incentives",
+      value: Math.round(30 * multiplier * 10) / 10,
+      percentage: 25,
+      color: "hsl(200, 98%, 39%)",
+    },
+    {
+      name: "Synthetic Hedges",
+      value: Math.round(24 * multiplier * 10) / 10,
+      percentage: 20,
+      color: "hsl(262, 83%, 58%)",
+    },
+    {
+      name: "Trading Fees",
+      value: Math.round(18 * multiplier * 10) / 10,
+      percentage: 15,
+      color: "hsl(24, 95%, 53%)",
+    },
+    {
+      name: "Governance Rewards",
+      value: Math.round(6 * multiplier * 10) / 10,
+      percentage: 5,
+      color: "hsl(340, 82%, 52%)",
+    },
+  ];
+
+  return {
+    total: sources.reduce((sum, s) => sum + s.value, 0),
+    sources,
+  };
+}


### PR DESCRIPTION
## Summary

Implements Portfolio Performance Attribution as specified in #110.

### Changes

- **PerformanceAttribution component** — Renders a horizontal stacked bar chart (recharts) showing yield breakdown by return source
- **Time-period selector** — Toggle between 1W, 1M, 3M, and All
- **Tooltip** — Shows percentage contribution per source on hover
- **API integration** — Fetches yield breakdown from backend AI API (`/api/attribution`) with local mock fallback
- **Integrated into dashboard** — Placed in the sidebar below AiInsightStream

### Files

- `frontend/components/PerformanceAttribution.tsx` — Chart component
- `frontend/lib/ai/fetchAttribution.ts` — Data fetching + local fallback
- `frontend/app/[locale]/page.tsx` — Dashboard integration

Closes #110