### PR TITLE
[FE-36] Reward Distribution View

### DIFF
--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -36,6 +36,7 @@ import { WithdrawTab } from "../../components/WithdrawTab";
 import { DepositTab } from "../../components/DepositTab";
 import { ReferralLinkCard } from "../../components/ReferralLinkCard";
 import { ReferralStatsCard } from "../../components/ReferralStatsCard";
+import { RewardSummary } from "../../components/RewardSummary";
 import { PartnerDashboard } from "../../components/PartnerDashboard";
 import { CurrencySwitch } from "../../components/CurrencySwitch";
 import { NetworkSwitch } from "../../components/NetworkSwitch";
@@ -347,7 +348,9 @@ export default function Home() {
                 <VaultAPYChart vaultId="main-vault" />
 
                 <TransactionHistoryList />
-                
+
+                <RewardSummary />
+
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                    <div className="bg-card border border-border p-6 rounded-2xl hover:border-primary/50 transition-colors group cursor-pointer">
                       <div className="flex justify-between items-start mb-4">

--- a/frontend/components/RewardSummary.test.tsx
+++ b/frontend/components/RewardSummary.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { RewardSummary } from "./RewardSummary";
+import { fetchRewardSummary } from "@/lib/rewards/fetchRewards";
+
+jest.mock("@/lib/rewards/fetchRewards", () => ({
+  fetchRewardSummary: jest.fn(),
+}));
+
+const mockFetchRewardSummary = fetchRewardSummary as jest.MockedFunction<typeof fetchRewardSummary>;
+
+describe("RewardSummary", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shows pending and claimed totals once data loads", async () => {
+    mockFetchRewardSummary.mockResolvedValue({
+      totalPending: 18.42,
+      totalClaimed: 12.5,
+      entries: [
+        { id: "1", source: "USDC Savings Vault", amount: "18.42", asset: "USDC", status: "pending", dateISO: "2024-03-10T00:00:00.000Z" },
+        { id: "2", source: "Referral Bonus", amount: "12.50", asset: "USDC", status: "claimed", dateISO: "2024-03-01T00:00:00.000Z" },
+      ],
+    });
+
+    render(<RewardSummary />);
+
+    expect(await screen.findByText("$18.42")).toBeInTheDocument();
+    expect(screen.getByText("$12.50")).toBeInTheDocument();
+    expect(screen.getByText("USDC Savings Vault")).toBeInTheDocument();
+    expect(screen.getByText("Referral Bonus")).toBeInTheDocument();
+    expect(screen.getByText("pending")).toBeInTheDocument();
+    expect(screen.getByText("claimed")).toBeInTheDocument();
+  });
+
+  it("shows an error state and allows retry when the fetch fails", async () => {
+    mockFetchRewardSummary.mockRejectedValueOnce(new Error("network error"));
+
+    render(<RewardSummary />);
+
+    await waitFor(() => expect(screen.getByText("Failed to load reward data")).toBeInTheDocument());
+  });
+
+  it("shows an empty state when there are no reward entries", async () => {
+    mockFetchRewardSummary.mockResolvedValue({ totalPending: 0, totalClaimed: 0, entries: [] });
+
+    render(<RewardSummary />);
+
+    expect(await screen.findByText("No rewards yet.")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/RewardSummary.tsx
+++ b/frontend/components/RewardSummary.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Clock, Gift, RefreshCw, CheckCircle2 } from "lucide-react";
+import { Card, CardHeader, CardTitle, CardContent } from "./ui/card";
+import { fetchRewardSummary } from "@/lib/rewards/fetchRewards";
+import type { RewardSummaryData } from "@/types/rewards";
+
+function formatUsd(value: number): string {
+  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function formatDate(dateISO: string): string {
+  return new Date(dateISO).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+export function RewardSummary() {
+  const [data, setData] = useState<RewardSummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchRewardSummary(signal);
+      setData(result);
+    } catch {
+      setError("Failed to load reward data");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  return (
+    <Card className="bg-card">
+      <CardHeader className="flex flex-row items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <Gift className="w-4 h-4 text-primary" />
+          <CardTitle className="text-lg">Reward Distribution</CardTitle>
+        </div>
+        <button
+          type="button"
+          onClick={() => load()}
+          className="p-2 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Refresh reward data"
+        >
+          <RefreshCw className="w-4 h-4" />
+        </button>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="min-h-[180px] flex items-center justify-center">
+            <p className="text-sm text-muted-foreground">Loading rewards...</p>
+          </div>
+        ) : error || !data ? (
+          <div className="min-h-[180px] flex flex-col items-center justify-center gap-2">
+            <p className="text-sm text-muted-foreground">{error}</p>
+            <button type="button" onClick={() => load()} className="text-sm text-primary hover:underline">
+              Try again
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="bg-muted/50 rounded-xl p-4">
+                <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground uppercase tracking-widest mb-1">
+                  <Clock className="w-3 h-3 text-yellow-500" />
+                  Pending
+                </div>
+                <p className="text-2xl font-black text-yellow-500">{formatUsd(data.totalPending)}</p>
+              </div>
+              <div className="bg-muted/50 rounded-xl p-4">
+                <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground uppercase tracking-widest mb-1">
+                  <CheckCircle2 className="w-3 h-3 text-green-500" />
+                  Claimed
+                </div>
+                <p className="text-2xl font-black text-green-500">{formatUsd(data.totalClaimed)}</p>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              {data.entries.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-4">No rewards yet.</p>
+              ) : (
+                data.entries.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className="flex justify-between items-center gap-2 pb-4 border-b border-border last:border-0 last:pb-0"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-bold truncate">{entry.source}</p>
+                      <p className="text-[10px] text-muted-foreground uppercase">{formatDate(entry.dateISO)}</p>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className="text-sm font-bold">
+                        {Number.parseFloat(entry.amount).toFixed(2)} {entry.asset}
+                      </p>
+                      <p
+                        className={`text-[10px] uppercase font-bold ${
+                          entry.status === "pending" ? "text-yellow-500" : "text-green-500"
+                        }`}
+                      >
+                        {entry.status}
+                      </p>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/rewards/fetchRewards.ts
+++ b/frontend/lib/rewards/fetchRewards.ts
@@ -1,0 +1,48 @@
+import type { RewardEntry, RewardSummaryData } from "@/types/rewards";
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8000";
+
+const MOCK_ENTRIES: RewardEntry[] = [
+  { id: "1", source: "USDC Savings Vault", amount: "18.42", asset: "USDC", status: "pending", dateISO: "2024-03-10T00:00:00.000Z" },
+  { id: "2", source: "Growth Index Vault", amount: "32.10", asset: "USDC", status: "pending", dateISO: "2024-03-08T00:00:00.000Z" },
+  { id: "3", source: "Referral Bonus", amount: "12.50", asset: "USDC", status: "claimed", dateISO: "2024-03-01T00:00:00.000Z" },
+  { id: "4", source: "Governance Staking", amount: "6.75", asset: "USDC", status: "claimed", dateISO: "2024-02-22T00:00:00.000Z" },
+  { id: "5", source: "USDC Savings Vault", amount: "9.30", asset: "USDC", status: "claimed", dateISO: "2024-02-15T00:00:00.000Z" },
+];
+
+function summarize(entries: RewardEntry[]): RewardSummaryData {
+  const totals = entries.reduce(
+    (acc, entry) => {
+      const value = Number.parseFloat(entry.amount) || 0;
+      if (entry.status === "pending") {
+        acc.totalPending += value;
+      } else {
+        acc.totalClaimed += value;
+      }
+      return acc;
+    },
+    { totalPending: 0, totalClaimed: 0 },
+  );
+
+  return { ...totals, entries };
+}
+
+/**
+ * Fetches the user's reward distribution breakdown from the backend.
+ *
+ * Calls NEXT_PUBLIC_BACKEND_URL/rewards/summary when configured; falls back
+ * to local mock data otherwise or on failure.
+ */
+export async function fetchRewardSummary(signal?: AbortSignal): Promise<RewardSummaryData> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/rewards/summary`, { signal });
+    if (res.ok) {
+      const json = (await res.json()) as { entries: RewardEntry[] };
+      return summarize(json.entries);
+    }
+  } catch {
+    // Fall through to local mock
+  }
+
+  return summarize(MOCK_ENTRIES);
+}

--- a/frontend/types/rewards.ts
+++ b/frontend/types/rewards.ts
@@ -1,0 +1,17 @@
+export type RewardStatus = "pending" | "claimed";
+
+export interface RewardEntry {
+  id: string;
+  source: string;
+  /** String representation; parse only for display formatting */
+  amount: string;
+  asset: string;
+  status: RewardStatus;
+  dateISO: string;
+}
+
+export interface RewardSummaryData {
+  totalPending: number;
+  totalClaimed: number;
+  entries: RewardEntry[];
+}


### PR DESCRIPTION
## [FE-36] Reward Distribution View

### Issue
[#103](https://github.com) — FE-36: Reward Distribution View
> Detailed breakdown of user rewards.

### Problem
There was no view showing users a breakdown of the rewards they've earned across vaults, referrals, and staking. The only existing surface (`ReferralStatsCard`) covers referral bonuses specifically, not the user's overall reward distribution, and nowhere shows the pending-vs-claimed split.

### What changed
Introduced a `RewardSummary` card that gives users a detailed, at-a-glance breakdown of their rewards, split into pending and claimed totals, and wired it into the main dashboard.

**1. Types — `frontend/types/rewards.ts`**
- `RewardStatus`: `"pending" | "claimed"`
- `RewardEntry`: a single reward line item (`id`, `source`, `amount`, `asset`, `status`, `dateISO`)
- `RewardSummaryData`: aggregated `totalPending` / `totalClaimed` plus the raw `entries` list

**2. Data layer — `frontend/lib/rewards/fetchRewards.ts`**
- `fetchRewardSummary(signal?)` fetches `GET {NEXT_PUBLIC_BACKEND_URL}/rewards/summary`
- Falls back to local mock data when the env var is unset, the request fails, or the response isn't OK — consistent with the existing `fetchAttribution.ts` pattern
- Aggregates raw entries into `totalPending` / `totalClaimed` client-side, so the UI never has to re-derive totals

**3. Component — `frontend/components/RewardSummary.tsx`**
- `Card`-based summary with two stat tiles: **Pending** (yellow) and **Claimed** (green)
- Detailed breakdown list below the tiles: reward source, date, amount + asset, and a status label per entry
- Loading, error (with retry), and empty states, plus a manual refresh button
- Follows the same visual/data-fetching conventions as `PerformanceAttribution` and `ReferralStatsCard` so it fits the existing dashboard look and feel

**4. Tests — `frontend/components/RewardSummary.test.tsx`**
- Renders pending/claimed totals and entry details once data resolves
- Shows the error state and retry affordance when the fetch rejects
- Shows the empty state when there are no reward entries

**5. Dashboard wiring — `frontend/app/[locale]/page.tsx`**
- Renders `<RewardSummary />` in the main dashboard column, directly below `TransactionHistoryList`, so it sits alongside the other "detailed breakdown" surfaces

### Acceptance criteria
- [x] Create `RewardSummary` card
- [x] Show pending vs. claimed rewards

### Screenshots
_Add a screenshot of the dashboard with the new Reward Distribution card here._

### Test plan
- [x] `npm install --legacy-peer-deps`
- [x] `npx jest` — 18 suites / 109 tests passing (3 new)
- [x] `npm run build` — succeeds (pre-existing `@stellar/stellar-sdk` webpack warnings only, unrelated to this change)

### Notes for reviewers
- No backend endpoint exists yet for `/rewards/summary`; the component gracefully falls back to mock data until one is available, matching how `fetchAttribution` handles the AI API today.
- Placement was chosen to mirror `TransactionHistoryList` (main column, detailed list) rather than the sidebar, since the acceptance criteria calls for a "detailed breakdown" rather than a compact stat.

Closes #103
